### PR TITLE
feat: precompute semantic embeddings with a shared public cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,14 @@ AI_MODEL=
 # Per-request timeout in ms (default 60000). Raise for a queued self-hosted gateway.
 AI_TIMEOUT_MS=60000
 
+# Separate embeddings service; never reuse the chat shim implicitly.
+# All three are required to enable: endpoint, model, immutable weights revision.
+EMBEDDING_BASE_URL=
+EMBEDDING_MODEL=
+EMBEDDING_MODEL_REVISION=
+# Optional only for a trusted local service without authentication.
+EMBEDDING_API_KEY=
+
 # Complete multi-user backups. Compose mounts the host directory at /backups;
 # keep that host path on an off-host-synced or otherwise protected volume.
 URTUBE_BACKUP_HOST_DIRECTORY=./backups

--- a/docker-compose.embeddings.yml
+++ b/docker-compose.embeddings.yml
@@ -1,0 +1,25 @@
+# Optional GPU service. See docs/semantic-matching.md before enabling.
+services:
+  embeddings:
+    image: vllm/vllm-openai:v0.28.0
+    gpus: all
+    restart: unless-stopped
+    environment:
+      VLLM_API_KEY: ${EMBEDDING_API_KEY:?Set a dedicated embedding API key}
+    command:
+      - --model
+      - BAAI/bge-m3
+      - --revision
+      - ${EMBEDDING_MODEL_REVISION:?Set the immutable BGE-M3 weights revision}
+      - --runner
+      - pooling
+      - --hf-overrides
+      - '{"architectures":["BgeM3EmbeddingModel"]}'
+      - --pooler-config
+      - '{"task":"embed"}'
+      - --max-model-len
+      - '512'
+    volumes:
+      - embeddings-model-cache:/root/.cache/huggingface
+volumes:
+  embeddings-model-cache:

--- a/docs/plans/2026-09-05-embeddings.md
+++ b/docs/plans/2026-09-05-embeddings.md
@@ -1,0 +1,9 @@
+# Background embedding cache (#45)
+
+Use the existing SQLite registry for a public-label-only cache and its atomic conditional updates for expiring request leases. Keep user-to-video-to-tag relations in owner databases. Reuse the service limiter; no new dependency or chat fallback. The embedding contract pins model, weights revision, 1024 dimensions, L2 normalization and label preprocessing.
+
+1. Add a strict OpenAI-compatible embeddings client with separate explicit configuration and a runnable capability probe.
+2. Add cache read/claim/finish methods. Deduplicate across accounts and worker processes; persist failures and completion-time cooldowns; expired leases recover after interruption.
+3. Read only fresh canonical semantic tags from each archive. Run embeddings after tags, independently of private taxonomy, with live contract-aware progress and bounded worker catch-up.
+4. Verify malformed indices/counts/dimensions/nonfinite/zero vectors, normalization, shared-label concurrency, version invalidation, restart/leases, failures and account deletion.
+5. Document pinned self-hosting setup and distinguish synthetic local checks from external GPU/service acceptance. Run the full check and independent review; open a stacked PR on #44.

--- a/docs/semantic-matching.md
+++ b/docs/semantic-matching.md
@@ -55,10 +55,92 @@ and account-file deletion cover the new table. No user relation is placed in
 a public cache. Model-service failure details are kept generic so response
 content or credentials do not leak into worker status.
 
+## Stage 2: background embeddings (#45)
+
+The separate `/embeddings` client requires explicit `EMBEDDING_BASE_URL`,
+`EMBEDDING_MODEL` and `EMBEDDING_MODEL_REVISION`. It never reads chat URL/model
+settings. Missing configuration is `unavailable`. A configured but failing or
+incompatible service produces persistent `error` state; it never completes
+with fabricated vectors. Every actual response is a capability check: model,
+count, unique complete indices, exactly 1024 finite values and nonzero norm.
+Vectors are L2-normalized locally, without truncation or padding.
+
+The registry's `embedding_cache` stores only normalized public labels,
+vectors, the model/weights/schema/preprocessing contract and request state.
+NFKC/case/whitespace normalization preserves punctuation. Fresh per-video tags
+remain the only owner relation, in each owner's database; changed metadata
+or tag contracts stop supplying stale labels immediately. Different model
+revisions use separate cache rows and are never mixed. Operators must change
+the revision whenever deployed weights change; the API cannot prove weights
+identity from a model name alone. Existing whole-registry backups include
+the cache. Deleting an account removes its archive and all derived relations;
+unattributed public vectors can remain reusable by other accounts.
+
+After tags, each cycle embeds up to 1024 distinct missing labels, in batches
+of 64. The single deployed worker has a shared two-request FIFO limit and
+60-second request timeout. Each batch has three total attempts, then a
+one-hour cooldown from failure completion. Atomic SQLite claims prevent
+overlapping accounts/processes from requesting the same label. A 210-second
+lease starts after acquiring a request slot; interruption allows later
+reclaim and a token guard prevents obsolete workers from overwriting it.
+Completed batches survive other failures, including private-classifier
+failures. Run one worker process per deployment to keep the two-request
+service-wide concurrency budget.
+
+`semantic_embeddings_progress` stores the latest owner-local progress
+snapshot. Call `semanticEmbeddingProgress()` for current contract-aware
+counts/status after imports or configuration changes; it is read-only.
+`embeddingWorkPending()` drives catch-up for due work. UI queries do not call
+the model. Empty archives or completed tags with no valid labels require no
+embedding request; downstream eligibility still decides whether matching has
+enough data.
+
+### Self-hosted setup and capability check
+
+The selected model is [BAAI/bge-m3](https://huggingface.co/BAAI/bge-m3), whose
+dense vectors have 1024 dimensions. The optional Compose file pins
+[vLLM 0.28.0](https://github.com/vllm-project/vllm/releases/tag/v0.28.0), uses
+the documented [BGE-M3 architecture override](https://docs.vllm.ai/en/v0.17.0/models/pooling_models/#baaibge-m3),
+and selects the dense `embed` task via its
+[pooler configuration](https://github.com/vllm-project/vllm/blob/v0.28.0/vllm/config/pooler.py).
+It requires a Linux NVIDIA GPU host with Docker Compose GPU support,
+NVIDIA Container Toolkit and a driver compatible with the pinned image's
+CUDA 13.0 runtime. No GPU memory or throughput measurement is claimed here.
+
+In `.env`, add a dedicated random key (generate with `openssl rand -hex 32`)
+and these explicit values. The weights revision was checked against the
+official model repository on 2026-09-05:
+
+```dotenv
+EMBEDDING_BASE_URL=http://embeddings:8000/v1
+EMBEDDING_MODEL=BAAI/bge-m3
+EMBEDDING_MODEL_REVISION=5617a9f61b028005a4858fdac845db406aefb181
+EMBEDDING_API_KEY=replace-with-your-generated-key
+```
+
+```sh
+docker compose -f docker-compose.yml -f docker-compose.embeddings.yml up -d --build
+docker compose -f docker-compose.yml -f docker-compose.embeddings.yml logs --tail=50 embeddings
+docker compose -f docker-compose.yml -f docker-compose.embeddings.yml exec worker npm run embeddings:check
+```
+
+The model endpoint is available only on the Compose network. The check sends
+two public fixture labels and exits nonzero unless the real service satisfies
+the full contract. Successful validation prints the contract, never the key
+or vectors. For a native app, explicitly set the same variables for an
+accessible dedicated endpoint and run `npm run embeddings:check`; do not use
+the Compose-only hostname. npm scripts inherit environment variables; to use
+a local `.env` explicitly run
+`node --env-file=.env --import tsx scripts/check-embeddings.ts`.
+
+Local checks cover synthetic HTTP responses, concurrency, version changes,
+restart/lease recovery, stale writes, privacy and failure isolation. The GPU
+image/model was not started in this development workspace; external service
+capability and deployment acceptance remain to be run on the intended host.
+
 ## Delivery boundary
 
-This stage does not change candidate scores or publish semantic interests.
-#45 adds the explicitly configured embedding service/cache, #46 weighted
-DBSCAN groups, and #47-#49 the projection, score, explanations and category
-filters. Until those stages are integrated, existing matching remains the
-existing algorithm and must not be described as semantic matching.
+Tags and vectors do not yet replace candidate scores or publish semantic
+interests. #46 adds weighted DBSCAN groups; #47–#49 integrate projection,
+scores, explanations and category filters. Until those stages are integrated,
+existing matching must not be described as semantic matching.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "worker": "tsx src/youtube-worker.ts",
     "youtube:import": "tsx src/import-youtube.ts",
     "youtube:topics:rebuild": "tsx src/youtube-topics.ts",
+    "embeddings:check": "tsx scripts/check-embeddings.ts",
     "demo:matching": "NODE_ENV=test tsx scripts/matching-demo.ts",
     "extension:release": "tsx scripts/build-extension-release.ts",
     "user:create": "tsx scripts/create-user.ts",

--- a/scripts/check-embeddings.ts
+++ b/scripts/check-embeddings.ts
@@ -1,0 +1,8 @@
+import { checkEmbeddingCapability } from '../src/youtube/embeddings.js';
+
+try {
+  console.log(`Embedding capability verified: ${await checkEmbeddingCapability()}`);
+} catch {
+  console.error('Embedding capability unavailable: check explicit EMBEDDING_* configuration, connectivity, model and 1024-dimensional float response.');
+  process.exitCode = 1;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,6 +85,12 @@ export const config = {
     // fan-out. Match the gateway's own concurrency (docs/ai-gateway.md).
     concurrency: Math.max(1, Math.min(16, Number(process.env.AI_CONCURRENCY ?? 4) || 4)),
   },
+  embeddings: {
+    baseUrl: (process.env.EMBEDDING_BASE_URL ?? '').replace(/\/$/, ''),
+    apiKey: process.env.EMBEDDING_API_KEY ?? '',
+    model: process.env.EMBEDDING_MODEL ?? '',
+    revision: process.env.EMBEDDING_MODEL_REVISION ?? '',
+  },
   opsStatusDirectory: process.env.OPS_STATUS_DIRECTORY
     ?? dirname(process.env.DATABASE_PATH ?? './data/urtube.sqlite'),
   backup: {

--- a/src/data/database.ts
+++ b/src/data/database.ts
@@ -2466,6 +2466,16 @@ export class Repository {
       input.videoId, input.metadataHash).changes > 0;
   }
 
+  youtubeSemanticLabels(contract: string): string[] {
+    return (this.db.prepare(`
+      SELECT DISTINCT json_extract(tag.value, '$.label') label
+      FROM youtube_semantic_tags s JOIN youtube_videos v ON v.video_id=s.video_id,
+        json_each(s.tags_json) tag
+      WHERE s.contract=? AND s.metadata_hash=v.metadata_hash AND s.status='ready'
+      ORDER BY label
+    `).all(contract) as Array<{ label: string }>).map(row => row.label);
+  }
+
   youtubeSemanticTagResult(videoId: string, contract: string): SemanticTagResult | null {
     const row = this.db.prepare(`
       SELECT s.* FROM youtube_semantic_tags s JOIN youtube_videos v ON v.video_id=s.video_id

--- a/src/users.ts
+++ b/src/users.ts
@@ -352,6 +352,18 @@ export class UserRegistry {
         ON match_requests(sender_user_id, recipient_user_id) WHERE status='pending';
       CREATE INDEX IF NOT EXISTS match_requests_participants
         ON match_requests(recipient_user_id, sender_user_id, status, updated_at DESC);
+      -- Public labels and vectors only. Owner relations stay in their archive.
+      CREATE TABLE IF NOT EXISTS embedding_cache (
+        contract TEXT NOT NULL,
+        label TEXT NOT NULL,
+        status TEXT NOT NULL CHECK(status IN ('processing','ready','error')),
+        vector_json TEXT CHECK(vector_json IS NULL OR json_valid(vector_json)),
+        lease_token TEXT,
+        retry_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY(contract, label),
+        CHECK((status='ready') = (vector_json IS NOT NULL))
+      );
     `);
     const profileColumns = this.db.prepare("SELECT name FROM pragma_table_info('matching_profiles')")
       .all() as Array<{ name: string }>;
@@ -376,6 +388,37 @@ export class UserRegistry {
         SELECT 1 FROM matching_profiles p WHERE p.user_id=users.id
       )
     `);
+  }
+
+  embeddingCacheStates(contract: string, labels: string[]): Map<string, { status: 'processing' | 'ready' | 'error'; retryAt: string }> {
+    const rows = this.db.prepare(`SELECT label, status, retry_at retryAt FROM embedding_cache
+      WHERE contract=? AND label IN (SELECT value FROM json_each(?))`)
+      .all(contract, JSON.stringify(labels)) as Array<{ label: string; status: 'processing' | 'ready' | 'error'; retryAt: string }>;
+    return new Map(rows.map(row => [row.label, { status: row.status, retryAt: row.retryAt }]));
+  }
+
+  embeddingVector(contract: string, label: string): number[] | null {
+    const row = this.db.prepare(`SELECT vector_json FROM embedding_cache
+      WHERE contract=? AND label=? AND status='ready'`).get(contract, label) as { vector_json: string } | undefined;
+    return row ? JSON.parse(row.vector_json) : null;
+  }
+
+  claimEmbedding(contract: string, label: string, token: string, leaseUntil: string, at: string): boolean {
+    return this.db.prepare(`INSERT INTO embedding_cache
+      (contract, label, status, vector_json, lease_token, retry_at, updated_at)
+      VALUES (?, ?, 'processing', NULL, ?, ?, ?)
+      ON CONFLICT(contract, label) DO UPDATE SET status='processing', vector_json=NULL,
+        lease_token=excluded.lease_token, retry_at=excluded.retry_at, updated_at=excluded.updated_at
+      WHERE embedding_cache.status<>'ready' AND embedding_cache.retry_at<=excluded.updated_at
+    `).run(contract, label, token, leaseUntil, at).changes > 0;
+  }
+
+  finishEmbedding(contract: string, label: string, token: string, vector: number[] | null, at: string, retryAt: string): boolean {
+    return this.db.prepare(`UPDATE embedding_cache SET status=?, vector_json=?,
+      lease_token=NULL, updated_at=?, retry_at=?
+      WHERE contract=? AND label=? AND lease_token=? AND status='processing'
+    `).run(vector ? 'ready' : 'error', vector ? JSON.stringify(vector) : null,
+      at, retryAt, contract, label, token).changes > 0;
   }
 
   private expireLoginState(): void {

--- a/src/youtube-worker.ts
+++ b/src/youtube-worker.ts
@@ -13,6 +13,7 @@ import { classifyYoutubeVideosForMatching, youtubeMatchingWorkPending } from './
 import { runYoutubePortabilityStep } from './youtube/portability.js';
 import { registryMatchingCrystal } from './youtube/registry-crystal.js';
 import { extractSemanticTags, semanticTagContract } from './youtube/semantic-tags.js';
+import { embedSemanticTags, embeddingWorkPending } from './youtube/embeddings.js';
 import {
   YOUTUBE_WORKER_CATCHUP_MINUTES,
   YOUTUBE_WORKER_FULL_CYCLE_MINUTES,
@@ -31,6 +32,7 @@ export interface YoutubeWorkerSteps {
   channelMetadata(repository: Repository, user: User): Promise<number>;
   matchingClassification(repository: Repository, user: User): Promise<number>;
   semanticTags(repository: Repository, user: User): Promise<number>;
+  embeddings(registry: UserRegistry, repository: Repository, user: User): Promise<number>;
   classification(repository: Repository, user: User): Promise<number>;
 }
 
@@ -41,6 +43,7 @@ export interface YoutubeWorkerUserResult {
   channelMetadata?: number;
   matchingClassified?: number;
   semanticTagged?: number;
+  embedded?: number;
   classified?: number;
   error?: string;
 }
@@ -55,6 +58,7 @@ const defaultSteps: YoutubeWorkerSteps = {
   matchingClassification: async (repository) =>
     classifyYoutubeVideosForMatching(repository, YOUTUBE_WORKER_METADATA_PER_CYCLE),
   semanticTags: (repository) => extractSemanticTags(repository, YOUTUBE_WORKER_TOPICS_PER_CYCLE),
+  embeddings: (registry, repository) => embedSemanticTags(registry, repository),
   // A deep extension backfill can also contain tens of thousands of videos.
   // Recency ordering makes the current dashboard useful first; a larger
   // cycle keeps new extension-only accounts from waiting days for analysis.
@@ -93,10 +97,13 @@ export async function runYoutubeWorkerCycle(
       // outage cannot leave a stale crystal in the registry.
       const crystal = registryMatchingCrystal(buildYoutubeCrystal(repository, user, now()));
       registry.upsertMatchingCrystal(user, crystal);
-      const [semantic, personal] = await Promise.allSettled([
-        steps.semanticTags(repository, user), steps.classification(repository, user),
+      const tagging = steps.semanticTags(repository, user);
+      // A partially failed tag cycle may still have fresh completed batches to embed.
+      const embedding = tagging.catch(() => {}).then(() => steps.embeddings(registry, repository, user));
+      const [semantic, embedded, personal] = await Promise.allSettled([
+        tagging, embedding, steps.classification(repository, user),
       ]);
-      const errors = [semantic, personal].flatMap(result => result.status === 'rejected'
+      const errors = [semantic, embedded, personal].flatMap(result => result.status === 'rejected'
         ? [errorMessage(result.reason)] : []).join('\n');
       repository.setYoutubeSyncState('last_error', errors.slice(0, 2000));
       return {
@@ -106,6 +113,7 @@ export async function runYoutubeWorkerCycle(
         channelMetadata,
         matchingClassified,
         semanticTagged: semantic.status === 'fulfilled' ? semantic.value : 0,
+        embedded: embedded.status === 'fulfilled' ? embedded.value : 0,
         classified: personal.status === 'fulfilled' ? personal.value : 0,
         ...(errors ? { error: errors } : {}),
       };
@@ -120,7 +128,8 @@ export async function runYoutubeWorkerCycle(
 export function youtubeWorkerMadeProgress(results: YoutubeWorkerUserResult[]): boolean {
   return results.some((result) =>
     (result.metadata ?? 0) + (result.channelMetadata ?? 0)
-      + (result.matchingClassified ?? 0) + (result.semanticTagged ?? 0) + (result.classified ?? 0) > 0);
+      + (result.matchingClassified ?? 0) + (result.semanticTagged ?? 0)
+      + (result.embedded ?? 0) + (result.classified ?? 0) > 0);
 }
 
 export function youtubeWorkerShouldContinue(
@@ -157,6 +166,7 @@ export function youtubeWorkPending(
   return registry.listUsers().some((user) => {
     const repository = registry.repositoryFor(user);
     return youtubeMatchingWorkPending(repository)
+      || embeddingWorkPending(registry, repository)
       || (youtubeClassificationConfigured()
         && repository.youtubeVideosForSemanticTags(semanticTagContract(), 1).length > 0)
       || describeYoutubeProcessing(repository.youtubeProcessingCounts(), capabilities).pending > 0;

--- a/src/youtube/embeddings.ts
+++ b/src/youtube/embeddings.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+import { config } from '../config.js';
+import type { Repository } from '../data/database.js';
+import type { UserRegistry } from '../users.js';
+import { createAsyncLimiter } from './concurrency.js';
+import { normalizeSemanticLabel, semanticTagContract } from './semantic-tags.js';
+
+export const EMBEDDING_POLICY = {
+  schema: 1, preprocessing: 1, dimensions: 1024, normalization: 'l2',
+  batchSize: 64, concurrency: 2, timeoutMs: 60_000, attempts: 3,
+  cycleLimit: 1024, retryMs: 3600_000, leaseMs: 210_000,
+} as const;
+
+export interface EmbeddingClient {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+  revision: string;
+  fetchImpl?: typeof fetch;
+}
+
+export const defaultEmbeddingClient = (): EmbeddingClient => config.embeddings;
+
+export function embeddingsConfigured(client = defaultEmbeddingClient()): boolean {
+  try {
+    const url = new URL(client.baseUrl);
+    return Boolean(client.model.trim() && client.revision.trim()
+      && ['http:', 'https:'].includes(url.protocol) && !url.username && !url.password && !url.search && !url.hash);
+  } catch { return false; }
+}
+
+export function embeddingContract(client = defaultEmbeddingClient()): string {
+  return JSON.stringify({ schema: EMBEDDING_POLICY.schema, preprocessing: EMBEDDING_POLICY.preprocessing,
+    dimensions: EMBEDDING_POLICY.dimensions, normalization: EMBEDDING_POLICY.normalization,
+    model: client.model, revision: client.revision });
+}
+
+const requestSlot = createAsyncLimiter(EMBEDDING_POLICY.concurrency);
+const responseSchema = z.object({ model: z.string(), data: z.array(z.object({
+  index: z.number().int().nonnegative(), embedding: z.array(z.number().finite()).length(EMBEDDING_POLICY.dimensions),
+})).max(EMBEDDING_POLICY.batchSize) });
+
+export function validateEmbeddings(raw: unknown, count: number, model: string): number[][] {
+  const result = responseSchema.parse(raw);
+  if (result.model !== model || result.data.length !== count) throw new Error('Embedding model or count mismatch');
+  const seen = new Set<number>();
+  const ordered = new Array<number[]>(count);
+  for (const item of result.data) {
+    if (item.index >= count || seen.has(item.index)) throw new Error('Embedding indices must occur exactly once');
+    seen.add(item.index);
+    const norm = Math.hypot(...item.embedding);
+    if (!Number.isFinite(norm) || norm === 0) throw new Error('Embedding norm must be finite and nonzero');
+    ordered[item.index] = item.embedding.map(value => value / norm);
+  }
+  return ordered;
+}
+
+async function requestEmbeddings(labels: string[], client: EmbeddingClient): Promise<number[][]> {
+  const response = await (client.fetchImpl ?? fetch)(`${client.baseUrl.replace(/\/$/, '')}/embeddings`, {
+    method: 'POST', redirect: 'error', signal: AbortSignal.timeout(EMBEDDING_POLICY.timeoutMs),
+    headers: { 'Content-Type': 'application/json', ...(client.apiKey ? { Authorization: `Bearer ${client.apiKey}` } : {}) },
+    body: JSON.stringify({ model: client.model, input: labels, encoding_format: 'float' }),
+  });
+  if (!response.ok) throw new Error('Embedding service request failed');
+  return validateEmbeddings(await response.json(), labels.length, client.model);
+}
+
+export async function checkEmbeddingCapability(client = defaultEmbeddingClient()): Promise<string> {
+  if (!embeddingsConfigured(client)) throw new Error('Embedding endpoint, model and immutable revision must be configured');
+  await requestSlot(() => requestEmbeddings(['basketball', '籃球'], client));
+  return embeddingContract(client);
+}
+
+function currentLabels(repository: Repository, tagsContract: string): string[] {
+  return [...new Set(repository.youtubeSemanticLabels(tagsContract).map(normalizeSemanticLabel))].sort();
+}
+
+export function semanticEmbeddingProgress(
+  registry: UserRegistry, repository: Repository, client = defaultEmbeddingClient(), tagsContract = semanticTagContract(),
+) {
+  const contract = embeddingContract(client);
+  const labels = currentLabels(repository, tagsContract);
+  const states = registry.embeddingCacheStates(contract, labels);
+  const completed = [...states.values()].filter(value => value.status === 'ready').length;
+  const errors = [...states.values()].filter(value => value.status === 'error').length;
+  const upstream = repository.youtubeSemanticTagCounts(tagsContract);
+  const pendingVideos = upstream.pending + upstream.metadataPending;
+  const pending = labels.length - completed - errors;
+  const status = !embeddingsConfigured(client) ? 'unavailable'
+    : errors || upstream.errors ? 'error'
+    : pending || pendingVideos ? 'processing' : 'ready';
+  return { status, contract, total: labels.length, completed, errors, pending, pendingVideos };
+}
+
+export function embeddingWorkPending(registry: UserRegistry, repository: Repository, client = defaultEmbeddingClient(), tagsContract = semanticTagContract(), now = new Date()): boolean {
+  if (!embeddingsConfigured(client)) return false;
+  const labels = currentLabels(repository, tagsContract);
+  const states = registry.embeddingCacheStates(embeddingContract(client), labels);
+  return labels.some(label => !states.has(label)
+    || (states.get(label)!.status !== 'ready' && states.get(label)!.retryAt <= now.toISOString()));
+}
+
+export async function embedSemanticTags(
+  registry: UserRegistry, repository: Repository, client = defaultEmbeddingClient(),
+  tagsContract = semanticTagContract(), now = () => new Date(),
+): Promise<number> {
+  const persistProgress = () => repository.setYoutubeSyncState('semantic_embeddings_progress',
+    JSON.stringify(semanticEmbeddingProgress(registry, repository, client, tagsContract)));
+  if (!embeddingsConfigured(client)) { persistProgress(); return 0; }
+  const contract = embeddingContract(client);
+  const labels = currentLabels(repository, tagsContract);
+  const states = registry.embeddingCacheStates(contract, labels);
+  const due = labels.filter(label => !states.has(label)
+    || (states.get(label)!.status !== 'ready' && states.get(label)!.retryAt <= now().toISOString()))
+    .slice(0, EMBEDDING_POLICY.cycleLimit);
+  const batches: string[][] = [];
+  for (let i = 0; i < due.length; i += EMBEDDING_POLICY.batchSize) batches.push(due.slice(i, i + EMBEDDING_POLICY.batchSize));
+  let completed = 0;
+  let failed = false;
+  await Promise.all(batches.map(batch => requestSlot(async () => {
+    const token = randomUUID();
+    const at = now();
+    // Claim only after reaching a request slot, so time spent queued cannot expire the lease.
+    const claimed = batch.filter(label => registry.claimEmbedding(contract, label, token,
+      new Date(at.getTime() + EMBEDDING_POLICY.leaseMs).toISOString(), at.toISOString()));
+    if (!claimed.length) return;
+    for (let attempt = 0; attempt < EMBEDDING_POLICY.attempts; attempt++) {
+      try {
+        const vectors = await requestEmbeddings(claimed, client);
+        claimed.forEach((label, index) => {
+          const stamp = now().toISOString();
+          if (registry.finishEmbedding(contract, label, token, vectors[index], stamp, stamp)) completed++;
+        });
+        return;
+      } catch {
+        if (attempt + 1 < EMBEDDING_POLICY.attempts) continue;
+        failed = true;
+        const finished = now();
+        for (const label of claimed) registry.finishEmbedding(contract, label, token, null,
+          finished.toISOString(), new Date(finished.getTime() + EMBEDDING_POLICY.retryMs).toISOString());
+      }
+    }
+  })));
+  persistProgress();
+  if (failed) throw new Error('Embedding request or validation failed after 3 attempts; retry state is saved');
+  return completed;
+}

--- a/tests/embeddings.test.ts
+++ b/tests/embeddings.test.ts
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import test from 'node:test';
+import { UserRegistry } from '../src/users.js';
+import { runYoutubeWorkerCycle, youtubeWorkerMadeProgress } from '../src/youtube-worker.js';
+import {
+  EMBEDDING_POLICY, checkEmbeddingCapability, embedSemanticTags, embeddingContract,
+  embeddingsConfigured, embeddingWorkPending, semanticEmbeddingProgress, validateEmbeddings,
+  type EmbeddingClient,
+} from '../src/youtube/embeddings.js';
+
+const client: EmbeddingClient = { baseUrl: 'http://127.0.0.1:8000/v1', apiKey: '', model: 'BAAI/bge-m3', revision: 'fixture-weights' };
+const tagsContract = 'fixture-public-tags-v1';
+const vector = () => [3, 4, ...Array(1022).fill(0)];
+const payload = (count = 1) => ({ model: client.model, data: Array.from({ length: count }, (_, index) => ({ index, embedding: vector() })) });
+
+function archive(registry: UserRegistry, handle: string, labels = ['Basketball']) {
+  const user = registry.createUser(handle, handle);
+  const repository = registry.repositoryFor(user);
+  for (let index = 0; index < labels.length; index += 5) {
+    const batch = labels.slice(index, index + 5);
+    const videoId = `public-video-${index}`;
+    repository.upsertYoutubeVideoMetadata([{ videoId, title: batch.join(', '),
+      channelTitle: null, channelId: null, description: '', tags: batch, thumbnailUrl: '',
+      durationSeconds: 60, publishedAt: null, categoryId: '17', availability: 'available', metadataHash: 'hash-v1' }]);
+    repository.saveYoutubeSemanticTagResult({ videoId, metadataHash: 'hash-v1', contract: tagsContract,
+      status: 'ready', tags: batch.map(label => ({ label, categoryKey: 'sports-fitness',
+        confidence: 0.9, source: 'tag', evidence: label })), error: null });
+  }
+  return { user, repository };
+}
+
+test('embeddings enforce explicit service configuration and exact vectors without padding or truncation', async () => {
+  assert.equal(embeddingsConfigured(client), true);
+  for (const invalid of [{ model: '' }, { revision: '' }, { baseUrl: '' }, { baseUrl: 'file:///tmp/model' }, { baseUrl: 'https://user:secret@example.com/v1' }]) {
+    assert.equal(embeddingsConfigured({ ...client, ...invalid }), false);
+  }
+  assert.deepEqual(validateEmbeddings(payload(), 1, client.model)[0].slice(0, 2), [0.6, 0.8]);
+  const reversed = payload(2); reversed.data[1].embedding[0] = 0; reversed.data.reverse();
+  assert.deepEqual(validateEmbeddings(reversed, 2, client.model).map(item => item.slice(0, 2)), [[0.6, 0.8], [0, 1]]);
+  assert.throws(() => validateEmbeddings({ ...payload(2), data: [payload().data[0], payload().data[0]] }, 2, client.model), /indices/);
+  for (const invalid of [
+    { ...payload(), model: 'wrong-model' }, payload(0), payload(2),
+    { ...payload(), data: [{ index: -1, embedding: vector() }] },
+    { ...payload(), data: [{ index: 1, embedding: vector() }] },
+    { ...payload(2), data: [payload().data[0], payload().data[0]] },
+    ...[[], vector().slice(1), [...vector(), 1], Array(1024).fill(0),
+      [NaN, ...vector().slice(1)], [Infinity, ...vector().slice(1)],
+    ].map(embedding => ({ ...payload(), data: [{ index: 0, embedding }] })),
+  ]) assert.throws(() => validateEmbeddings(invalid, 1, client.model));
+  await checkEmbeddingCapability({ ...client, fetchImpl: async (url, options) => {
+    assert.equal(String(url), `${client.baseUrl}/embeddings`);
+    assert.equal(options?.redirect, 'error');
+    assert.ok(options?.signal);
+    const request = JSON.parse(String(options?.body));
+    assert.deepEqual(request, { model: client.model, input: ['basketball', '籃球'], encoding_format: 'float' });
+    return Response.json(payload(2));
+  } });
+});
+
+test('concurrent accounts reuse only public labels, cap batches and concurrency, and invalidate stale input/contracts', async () => {
+  const registry = new UserRegistry(':memory:');
+  const labels = Array.from({ length: 130 }, (_, index) => `Public sport ${index}`);
+  const alice = archive(registry, 'private-alice', labels);
+  const bob = archive(registry, 'private-bob', [...labels, 'PUBLIC SPORT 0']);
+  let active = 0, peak = 0;
+  const requested: string[] = [];
+  const mocked: EmbeddingClient = { ...client, fetchImpl: async (_url, options) => {
+    const request = JSON.parse(String(options?.body));
+    assert.deepEqual(Object.keys(request).sort(), ['encoding_format', 'input', 'model']);
+    assert.ok(request.input.length <= 64);
+    assert.ok(request.input.every((label: string) => label.startsWith('public sport ')));
+    requested.push(...request.input);
+    peak = Math.max(peak, ++active);
+    await new Promise(resolve => setTimeout(resolve, 5));
+    active--;
+    return Response.json(payload(request.input.length));
+  } };
+  try {
+    const results = await Promise.all([alice, bob].map(({ repository }) => embedSemanticTags(registry, repository, mocked, tagsContract)));
+    assert.equal(results.reduce((sum, value) => sum + value, 0), 130);
+    assert.equal(requested.length, 130);
+    assert.equal(new Set(requested).size, 130);
+    assert.equal(peak, 2);
+    assert.equal(await embedSemanticTags(registry, bob.repository, mocked, tagsContract), 0);
+    assert.equal(semanticEmbeddingProgress(registry, bob.repository, mocked, tagsContract).status, 'ready');
+    assert.equal(embeddingWorkPending(registry, bob.repository, mocked, tagsContract), false);
+    assert.equal(semanticEmbeddingProgress(registry, bob.repository, { ...mocked, revision: 'next' }, tagsContract).pending, 130);
+    assert.equal(registry.embeddingVector(embeddingContract({ ...mocked, revision: 'next' }), 'public sport 0'), null);
+    assert.equal(semanticEmbeddingProgress(registry, bob.repository, mocked, 'next-tags').pendingVideos, 27);
+    assert.equal(bob.repository.youtubeSemanticLabels('next-tags').length, 0);
+    assert.equal(await embedSemanticTags(registry, bob.repository, { ...mocked, baseUrl: '' }, tagsContract), 0);
+    assert.equal(JSON.parse(bob.repository.youtubeSyncState('semantic_embeddings_progress')!).status, 'unavailable');
+    registry.deleteUser(alice.user.handle);
+    assert.equal(registry.userByHandle(alice.user.handle), null);
+    assert.ok(registry.embeddingVector(embeddingContract(mocked), 'public sport 0'));
+    assert.equal(semanticEmbeddingProgress(registry, bob.repository, mocked, tagsContract).completed, 130);
+  } finally { registry.close(); }
+});
+
+test('worker embeds completed tags after partial tag failure and isolates account and private classifier failures', async () => {
+  const registry = new UserRegistry(':memory:');
+  const alice = archive(registry, 'failure-alice', ['Failed label']);
+  const bob = archive(registry, 'success-bob', ['Successful label']);
+  const tagged = new Set<string>();
+  const classified = new Set<string>();
+  const mocked: EmbeddingClient = { ...client, fetchImpl: async (_url, options) => {
+    const request = JSON.parse(String(options?.body));
+    if (request.input.includes('failed label')) return new Response('service fixture', { status: 503 });
+    return Response.json(payload(request.input.length));
+  } };
+  try {
+    const results = await runYoutubeWorkerCycle(registry, {
+      portability: async () => 'idle', metadata: async () => 2, channelMetadata: async () => 0,
+      matchingClassification: async () => 0,
+      semanticTags: async (_repository, user) => {
+        tagged.add(user.handle);
+        if (user.id === alice.user.id) throw new Error('partial tag failure');
+        return 1;
+      },
+      embeddings: async (cache, repository, user) => {
+        assert.ok(tagged.has(user.handle));
+        return embedSemanticTags(cache, repository, mocked, tagsContract);
+      },
+      classification: async (_repository, user) => { classified.add(user.handle); return 1; },
+    });
+    assert.equal(results.find(result => result.user === bob.user.handle)?.embedded, 1);
+    const failed = results.find(result => result.user === alice.user.handle)!;
+    assert.match(failed.error ?? '', /partial tag failure/);
+    assert.match(failed.error ?? '', /Embedding request/);
+    assert.equal(failed.metadata, 2);
+    assert.equal(failed.classified, 1);
+    assert.equal(classified.size, 2);
+    assert.equal(youtubeWorkerMadeProgress(results), true);
+  } finally { registry.close(); }
+});
+
+test('cache leases survive restart, reject stale owners, and failed service requests retain completion-time retry state', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'urtube-embeddings-'));
+  const path = join(directory, 'registry.sqlite');
+  let registry = new UserRegistry(path);
+  let elapsed = Date.now();
+  const now = () => new Date(elapsed);
+  const contract = embeddingContract(client);
+  const { user } = archive(registry, 'cache-owner');
+  try {
+    assert.equal(registry.claimEmbedding(contract, 'basketball', 'interrupted', new Date(elapsed + EMBEDDING_POLICY.leaseMs).toISOString(), now().toISOString()), true);
+    registry.close();
+    registry = new UserRegistry(path);
+    const otherProcess = new UserRegistry(path);
+    assert.equal(otherProcess.claimEmbedding(contract, 'basketball', 'duplicate', new Date(elapsed + EMBEDDING_POLICY.leaseMs).toISOString(), now().toISOString()), false);
+    otherProcess.close();
+    const repository = registry.repositoryFor(registry.userByHandle(user.handle)!);
+    assert.equal(embeddingWorkPending(registry, repository, client, tagsContract, now()), false);
+    elapsed += EMBEDDING_POLICY.leaseMs + 1;
+    let calls = 0;
+    const failing: EmbeddingClient = { ...client, fetchImpl: async () => {
+      calls++; elapsed += 60_000;
+      throw new Error('must not expose service credentials or response data');
+    } };
+    await assert.rejects(embedSemanticTags(registry, repository, failing, tagsContract, now), /3 attempts/);
+    assert.equal(calls, 3);
+    assert.equal(semanticEmbeddingProgress(registry, repository, client, tagsContract).status, 'error');
+    assert.equal(embeddingWorkPending(registry, repository, client, tagsContract, now()), false);
+    assert.equal(registry.finishEmbedding(contract, 'basketball', 'interrupted', vector(), now().toISOString(), now().toISOString()), false);
+    elapsed += EMBEDDING_POLICY.retryMs + 1;
+    const recovered: EmbeddingClient = { ...client, fetchImpl: async () => Response.json(payload()) };
+    assert.equal(await embedSemanticTags(registry, repository, recovered, tagsContract, now), 1);
+    registry.close(); registry = new UserRegistry(path);
+    assert.deepEqual(registry.embeddingVector(contract, 'basketball')?.slice(0, 2), [0.6, 0.8]);
+    const inspector = new DatabaseSync(path);
+    assert.deepEqual(inspector.prepare('PRAGMA table_info(embedding_cache)').all().map(row => row.name),
+      ['contract', 'label', 'status', 'vector_json', 'lease_token', 'retry_at', 'updated_at']);
+    inspector.close();
+    registry.deleteUser(user.handle);
+    assert.equal(registry.listUsers().length, 0);
+  } finally { registry.close(); rmSync(directory, { recursive: true, force: true }); }
+});

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -142,6 +142,7 @@ test('processing notice counts fall across catch-up cycles and disappear when se
       },
       matchingClassification: async (archive) => classifyYoutubeVideosForMatching(archive, 2),
       semanticTags: async () => 0,
+      embeddings: async () => 0,
       classification: async (archive) => {
         const videos = archive.youtubeVideosForPersonalClassification(run, 2);
         for (const video of videos) {
@@ -261,6 +262,7 @@ test('worker stamps each archive and reports pending work only for configured st
       channelMetadata: async () => 0,
       matchingClassification: async () => 0,
       semanticTags: async () => 0,
+      embeddings: async () => 0,
       classification: async () => { throw new Error('boom'); },
     };
     await runYoutubeWorkerCycle(registry, steps, () => new Date('2026-09-04T10:00:00Z'));

--- a/tests/registry-crystal.test.ts
+++ b/tests/registry-crystal.test.ts
@@ -202,6 +202,7 @@ test('worker publishes the queued matching crystal after successful processing',
       channelMetadata: async () => 0,
       matchingClassification: async () => 0,
       semanticTags: async () => 0,
+      embeddings: async () => 0,
       classification: async () => 0,
     };
     await runYoutubeWorkerCycle(

--- a/tests/youtube-worker.test.ts
+++ b/tests/youtube-worker.test.ts
@@ -28,6 +28,7 @@ test('YouTube worker enriches every user while keeping portability owner-only', 
       channelMetadata: step('channels'),
       matchingClassification: step('matching'),
       semanticTags: step('semantic'),
+      embeddings: async () => 0,
       classification: step('classification'),
     };
 
@@ -71,6 +72,7 @@ test('YouTube worker starts independent user archives concurrently', async () =>
       channelMetadata: async () => 0,
       matchingClassification: async () => 0,
       semanticTags: async () => 0,
+      embeddings: async () => 0,
       classification: async () => 0,
     };
 
@@ -103,6 +105,7 @@ test('one user failure is recorded without preventing later users from running',
       channelMetadata: async () => 0,
       matchingClassification: async () => 0,
       semanticTags: async () => 0,
+      embeddings: async () => 0,
       classification: async (_repository, user) => {
         classified.push(user.handle);
         return user.handle === bob.handle ? 1 : 0;
@@ -152,6 +155,7 @@ test('a failed semantic batch is isolated from other accounts and private taxono
         if (user.id === alice.id) throw new Error('semantic fixture failure');
         return 1;
       },
+      embeddings: async () => 0,
       classification: async (_archive, user) => { privateCalls.push(user.handle); return 0; },
     });
     assert.match(results.find(result => result.user === alice.handle)?.error ?? '', /semantic fixture failure/);


### PR DESCRIPTION
Adds the background tags → embeddings stage and a public-label-only shared SQLite cache. Matching requests never call the model. Accounts reuse vectors for the same normalized label and model contract; atomic expiring leases deduplicate overlapping workers, recover interruptions and reject stale completions.

The embeddings service has separate explicit endpoint/model/weights-revision settings. Requests use batches of 64, two concurrent slots, 60-second timeouts and three total attempts, followed by persistent completion-time retry cooldown. Responses must have the requested model, exact indices/count, 1024 finite dimensions and nonzero norm; vectors are L2-normalized without padding or truncation. Current-contract progress remains read-only and account relations stay in owner archives.

Setup: configure `EMBEDDING_BASE_URL`, `EMBEDDING_MODEL`, `EMBEDDING_MODEL_REVISION` and the service key. The optional GPU Compose overlay pins vLLM 0.28.0 and BGE-M3's dense embed task; run `npm run embeddings:check` in the configured worker. Full instructions are in `docs/semantic-matching.md`.

Validation: `npm run check` passes all 228 tests. Independent review approved. Verified the CLI against a synthetic HTTP server, its nonzero exit with missing configuration, and merged Compose configuration (internal-only model service). Tests cover malformed vectors, cross-account reuse/concurrency, restart, leases, revision invalidation, deletion and worker-stage failure isolation.

External acceptance still required: the GPU image and real BGE-M3 service were not started here, and deployed weights identity/throughput are not claimed. This stage does not replace matching scores; #46–#49 integrate clustering and matching.

Depends on #56 (stacked branch).

Fixes #45.
