### PR TITLE
feat: build weighted DBSCAN interest groups with explicit coverage

### DIFF
--- a/docs/plans/2026-09-05-interests.md
+++ b/docs/plans/2026-09-05-interests.md
@@ -1,0 +1,9 @@
+# Weighted personal interest groups (#46)
+
+Implement the specified cosine weighted DBSCAN, not an algorithm comparison. Existing dependencies provide no weighted clustering; the reviewed JavaScript density-clustering API counts neighbors rather than sample weight. Keep the small deterministic weighted expansion in TypeScript instead of adding an unweighted dependency or another runtime.
+
+1. Build bounded category samples from at most 2000 distinct recent videos. A video contributes one unit per category, divided among deduplicated labels. Keep at most 256 labels per category by support/key and expose dropped video/label/mass coverage.
+2. Cluster with epsilon 0.2 and minimum weighted neighborhood support 3. Preserve core/border/noise, use fixed key ordering, require three distinct supporting videos, normalize weighted centroids and keep five groups by mass/key.
+3. Store a versioned owner-only snapshot with exact input hash, coverage, model/tag/algorithm contracts and evidence. Query only 90-day current metadata/tag rows. Revalidate input on reads and recompute after expiration/import/deletion/version changes.
+4. Run groups after embeddings, isolating partial failures from private classification. Keep all vectors and video evidence out of the registry until #47 defines the bounded public projection.
+5. Verify separated/noise/weighted/repeated-video/multitag/core-border cases and deterministic caps. Test SQLite restart, invalidation and export. Run full checks and independent review before a stacked PR.

--- a/docs/semantic-matching.md
+++ b/docs/semantic-matching.md
@@ -138,9 +138,56 @@ restart/lease recovery, stale writes, privacy and failure isolation. The GPU
 image/model was not started in this development workspace; external service
 capability and deployment acceptance remain to be run on the intended host.
 
+## Stage 3: owner interest groups (#46)
+
+`interests.ts` implements the selected weighted DBSCAN policy: cosine distance
+`1 - dot(unit vectors)`, epsilon 0.2 and minimum neighborhood mass 3, including
+the point itself. Expansion follows standard core/border/noise semantics;
+border points cannot bridge core components. Fixed label ordering resolves
+ambiguous borders deterministically. This follows the documented
+[weighted DBSCAN definition](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.DBSCAN.html).
+The installed dependencies contain no weighted clustering primitive. The
+small weighted expansion remains in TypeScript; no second runtime or
+unweighted-neighbor approximation is introduced.
+
+Only distinct identified videos watched in the last 90 days contribute.
+Repeated watches do not multiply support. Each video contributes one unit
+in each canonical category, equally split across its deduplicated valid
+labels. Missing vectors and dropped labels retain their missing share;
+remaining samples are not inflated. Each resulting cluster also needs at
+least three distinct videos. A support-weighted centroid is normalized,
+and the five largest groups per category survive, with stable tie ordering.
+Zero-norm centroids and unsupported/noise groups are not emitted. Up to three
+member labels nearest the centroid are retained as evidence-backed
+representatives for the downstream extractive summary.
+
+The SQL window reads at most 2000 videos, newest first with video-ID ties.
+Preprocessing accepts at most 15 tags per video and uses at most 256 labels
+per category, selected by support then key. Categories are processed in
+sequence; each retains at most 256 vectors of 1024 values plus a bounded
+256-by-256 neighborhood graph. The quadratic radius scan never runs over
+the entire archive. Snapshot coverage records the full identified-video
+count, considered/processed/unavailable video counts, and each category's
+total versus used label count and mass. Truncation is `partial`, pending
+inputs are `processing`, failures are `error`, and missing service settings
+are `unavailable`. Unidentified Takeout events are counted separately as
+`unidentifiedEvents`; a missing video ID cannot become permanent queued work.
+
+Schema 15 adds one owner-only `youtube_interests` snapshot, exported as
+`semantic-interests.json` and covered by existing database backup/deletion.
+It includes private supporting video IDs, vectors, mass, representatives,
+model/tag/algorithm versions, input hash, generation time and next window
+expiration. `currentInterests()` checks the current bounded input hash and
+returns null after relevant import, deletion, metadata/tag/model change,
+embedding-readiness change or window movement; consumers must use this
+freshness-checked read instead of displaying a raw stored snapshot. The
+worker rebuilds after embeddings, including partial failures, without
+blocking the existing private classifier. No group evidence is published to
+the shared registry in this stage.
+
 ## Delivery boundary
 
-Tags and vectors do not yet replace candidate scores or publish semantic
-interests. #46 adds weighted DBSCAN groups; #47–#49 integrate projection,
+Tags, vectors and owner groups do not yet replace candidate scores or publish
+semantic interests. #47–#49 integrate projection,
 scores, explanations and category filters. Until those stages are integrated,
 existing matching must not be described as semantic matching.

--- a/src/data/database.ts
+++ b/src/data/database.ts
@@ -56,6 +56,7 @@ import {
 } from '../youtube/personal-taxonomy.js';
 import { decryptPrivateValue } from '../youtube/crypto.js';
 import type { SemanticTagResult } from '../youtube/semantic-tags.js';
+import type { InterestSnapshot, InterestVideo } from '../youtube/interests.js';
 
 export interface PersistResult { inserted: number; updated: number }
 
@@ -116,6 +117,7 @@ const PORTABLE_TABLES = [
   ['personal-topic-assignments.json', 'youtube_video_topics', 'Personal topic classifications and their provenance.'],
   ['matching-topic-assignments.json', 'youtube_video_matching_topics', 'Canonical matching-topic classifications.'],
   ['semantic-tags.json', 'youtube_semantic_tags', 'Evidence-backed canonical semantic tags, contracts and processing status.'],
+  ['semantic-interests.json', 'youtube_interests', 'Owner-only weighted interest groups, evidence, contracts and coverage.'],
   ['sync-state.json', 'youtube_sync_state', 'Data Portability and worker checkpoints.'],
   ['time-ledger.json', 'time_ledger', 'Derived daily measured and estimated time.'],
   ['time-ledger-state.json', 'time_ledger_state', 'Time-ledger processing checkpoints.'],
@@ -591,6 +593,14 @@ export class Repository {
         PRAGMA user_version = 14;
         COMMIT;
       `);
+    }
+    if (Number((this.db.prepare('PRAGMA user_version').get() as { user_version: number }).user_version) < 15) {
+      this.db.exec(`BEGIN IMMEDIATE;
+        CREATE TABLE IF NOT EXISTS youtube_interests (
+          id INTEGER PRIMARY KEY CHECK(id=1),
+          json TEXT NOT NULL CHECK(json_valid(json))
+        );
+        PRAGMA user_version=15; COMMIT;`);
     }
   }
 
@@ -2464,6 +2474,34 @@ export class Repository {
         error=excluded.error, updated_at=excluded.updated_at
     `).run(input.contract, input.status, JSON.stringify(input.tags), input.error, at,
       input.videoId, input.metadataHash).changes > 0;
+  }
+
+  youtubeInterestWindow(contract: string, start: string, end: string, limit: number): { total: number; unidentifiedEvents: number; firstExpiryWatch: string | null; videos: InterestVideo[] } {
+    const watched = `SELECT video_id, MAX(watched_at) watched_at FROM youtube_watch_events
+      WHERE activity_type='video' AND video_id IS NOT NULL AND watched_at>? AND watched_at<=? GROUP BY video_id`;
+    const stats = this.db.prepare(`SELECT COUNT(*) total, MIN(watched_at) firstExpiryWatch FROM (${watched})`)
+      .get(start, end) as { total: number; firstExpiryWatch: string | null };
+    const rows = this.db.prepare(`SELECT w.video_id, w.watched_at, v.metadata_hash,
+      s.status, s.tags_json FROM (${watched}) w LEFT JOIN youtube_videos v ON v.video_id=w.video_id
+      LEFT JOIN youtube_semantic_tags s ON s.video_id=w.video_id AND s.metadata_hash=v.metadata_hash AND s.contract=?
+      ORDER BY w.watched_at DESC, w.video_id LIMIT ?
+    `).all(start, end, contract, limit) as Array<Record<string, string | null>>;
+    const unidentifiedEvents = Number((this.db.prepare(`SELECT COUNT(*) count FROM youtube_watch_events
+      WHERE activity_type='video' AND video_id IS NULL AND watched_at>? AND watched_at<=?`)
+      .get(start, end) as { count: number }).count);
+    return { ...stats, unidentifiedEvents, videos: rows.map(row => ({ videoId: row.video_id!, watchedAt: row.watched_at!,
+      metadataHash: row.metadata_hash, status: (row.status ?? 'pending') as InterestVideo['status'],
+      tags: row.status === 'ready' ? JSON.parse(row.tags_json!) : [] })) };
+  }
+
+  saveYoutubeInterests(snapshot: InterestSnapshot): void {
+    this.db.prepare(`INSERT INTO youtube_interests(id,json) VALUES (1,?)
+      ON CONFLICT(id) DO UPDATE SET json=excluded.json`).run(JSON.stringify(snapshot));
+  }
+
+  youtubeInterests(): InterestSnapshot | null {
+    const row = this.db.prepare('SELECT json FROM youtube_interests WHERE id=1').get() as { json: string } | undefined;
+    return row ? JSON.parse(row.json) : null;
   }
 
   youtubeSemanticLabels(contract: string): string[] {

--- a/src/youtube-worker.ts
+++ b/src/youtube-worker.ts
@@ -13,7 +13,8 @@ import { classifyYoutubeVideosForMatching, youtubeMatchingWorkPending } from './
 import { runYoutubePortabilityStep } from './youtube/portability.js';
 import { registryMatchingCrystal } from './youtube/registry-crystal.js';
 import { extractSemanticTags, semanticTagContract } from './youtube/semantic-tags.js';
-import { embedSemanticTags, embeddingWorkPending } from './youtube/embeddings.js';
+import { embedSemanticTags, embeddingWorkPending, embeddingsConfigured } from './youtube/embeddings.js';
+import { buildSemanticInterests, currentInterests } from './youtube/interests.js';
 import {
   YOUTUBE_WORKER_CATCHUP_MINUTES,
   YOUTUBE_WORKER_FULL_CYCLE_MINUTES,
@@ -33,6 +34,7 @@ export interface YoutubeWorkerSteps {
   matchingClassification(repository: Repository, user: User): Promise<number>;
   semanticTags(repository: Repository, user: User): Promise<number>;
   embeddings(registry: UserRegistry, repository: Repository, user: User): Promise<number>;
+  interests(registry: UserRegistry, repository: Repository, user: User): Promise<number>;
   classification(repository: Repository, user: User): Promise<number>;
 }
 
@@ -44,6 +46,7 @@ export interface YoutubeWorkerUserResult {
   matchingClassified?: number;
   semanticTagged?: number;
   embedded?: number;
+  interestsBuilt?: number;
   classified?: number;
   error?: string;
 }
@@ -59,6 +62,7 @@ const defaultSteps: YoutubeWorkerSteps = {
     classifyYoutubeVideosForMatching(repository, YOUTUBE_WORKER_METADATA_PER_CYCLE),
   semanticTags: (repository) => extractSemanticTags(repository, YOUTUBE_WORKER_TOPICS_PER_CYCLE),
   embeddings: (registry, repository) => embedSemanticTags(registry, repository),
+  interests: async (registry, repository) => buildSemanticInterests(registry, repository),
   // A deep extension backfill can also contain tens of thousands of videos.
   // Recency ordering makes the current dashboard useful first; a larger
   // cycle keeps new extension-only accounts from waiting days for analysis.
@@ -100,10 +104,11 @@ export async function runYoutubeWorkerCycle(
       const tagging = steps.semanticTags(repository, user);
       // A partially failed tag cycle may still have fresh completed batches to embed.
       const embedding = tagging.catch(() => {}).then(() => steps.embeddings(registry, repository, user));
-      const [semantic, embedded, personal] = await Promise.allSettled([
-        tagging, embedding, steps.classification(repository, user),
+      const interests = embedding.catch(() => {}).then(() => steps.interests(registry, repository, user));
+      const [semantic, embedded, grouped, personal] = await Promise.allSettled([
+        tagging, embedding, interests, steps.classification(repository, user),
       ]);
-      const errors = [semantic, embedded, personal].flatMap(result => result.status === 'rejected'
+      const errors = [semantic, embedded, grouped, personal].flatMap(result => result.status === 'rejected'
         ? [errorMessage(result.reason)] : []).join('\n');
       repository.setYoutubeSyncState('last_error', errors.slice(0, 2000));
       return {
@@ -114,6 +119,7 @@ export async function runYoutubeWorkerCycle(
         matchingClassified,
         semanticTagged: semantic.status === 'fulfilled' ? semantic.value : 0,
         embedded: embedded.status === 'fulfilled' ? embedded.value : 0,
+        interestsBuilt: grouped.status === 'fulfilled' ? grouped.value : 0,
         classified: personal.status === 'fulfilled' ? personal.value : 0,
         ...(errors ? { error: errors } : {}),
       };
@@ -129,7 +135,7 @@ export function youtubeWorkerMadeProgress(results: YoutubeWorkerUserResult[]): b
   return results.some((result) =>
     (result.metadata ?? 0) + (result.channelMetadata ?? 0)
       + (result.matchingClassified ?? 0) + (result.semanticTagged ?? 0)
-      + (result.embedded ?? 0) + (result.classified ?? 0) > 0);
+      + (result.embedded ?? 0) + (result.interestsBuilt ?? 0) + (result.classified ?? 0) > 0);
 }
 
 export function youtubeWorkerShouldContinue(
@@ -167,6 +173,7 @@ export function youtubeWorkPending(
     const repository = registry.repositoryFor(user);
     return youtubeMatchingWorkPending(repository)
       || embeddingWorkPending(registry, repository)
+      || (embeddingsConfigured() && !currentInterests(registry, repository))
       || (youtubeClassificationConfigured()
         && repository.youtubeVideosForSemanticTags(semanticTagContract(), 1).length > 0)
       || describeYoutubeProcessing(repository.youtubeProcessingCounts(), capabilities).pending > 0;

--- a/src/youtube/interests.ts
+++ b/src/youtube/interests.ts
@@ -1,0 +1,211 @@
+import { createHash } from 'node:crypto';
+import type { Repository } from '../data/database.js';
+import type { UserRegistry } from '../users.js';
+import { defaultEmbeddingClient, embeddingContract, embeddingsConfigured, EMBEDDING_POLICY } from './embeddings.js';
+import { MATCHING_TAXONOMY, MATCHING_WINDOW_DAYS } from './matching.js';
+import { normalizeSemanticLabel, semanticTagContract, type SemanticTag, type SemanticTagResult } from './semantic-tags.js';
+
+export const INTEREST_POLICY = {
+  algorithmVersion: 1, epsilon: 0.2, minSupport: 3, maxGroups: 5,
+  maxVideos: 2000, maxLabelsPerCategory: 256, representatives: 3,
+  windowDays: MATCHING_WINDOW_DAYS, dimensions: EMBEDDING_POLICY.dimensions,
+} as const;
+
+export interface InterestVideo {
+  videoId: string;
+  watchedAt: string;
+  metadataHash: string | null;
+  status: SemanticTagResult['status'] | 'pending';
+  tags: SemanticTag[];
+}
+
+export interface InterestGroup {
+  categoryKey: string;
+  centroid: number[];
+  mass: number;
+  representativeTags: string[];
+  supportingVideoIds: string[];
+  modelContract: string;
+  algorithmVersion: number;
+}
+
+export interface InterestSnapshot {
+  inputHash: string;
+  modelContract: string;
+  tagsContract: string;
+  algorithmVersion: number;
+  generatedAt: string;
+  validUntil: string | null;
+  status: 'ready' | 'partial' | 'processing' | 'unavailable' | 'error';
+  groups: InterestGroup[];
+  coverage: {
+    windowVideos: number;
+    consideredVideos: number;
+    processedVideos: number;
+    unavailableVideos: number;
+    unidentifiedEvents: number;
+    categories: CategoryCoverage[];
+  };
+}
+
+interface Sample {
+  key: string;
+  label: string;
+  weight: number;
+  videoIds: string[];
+}
+interface CategoryCoverage {
+  categoryKey: string;
+  totalLabels: number;
+  usedLabels: number;
+  totalMass: number;
+  usedMass: number;
+}
+export interface WeightedInterestPoint extends Sample { vector: number[] }
+const byKey = (a: { key: string }, b: { key: string }) => a.key.localeCompare(b.key, 'en');
+const dot = (a: number[], b: number[]) => a.reduce((sum, value, i) => sum + value * b[i], 0);
+
+function unitVector(vector: number[]): number[] {
+  if (vector.length !== INTEREST_POLICY.dimensions || vector.some(value => !Number.isFinite(value))) {
+    throw new Error('Interest vector has invalid dimensions or values');
+  }
+  const norm = Math.hypot(...vector);
+  if (!Number.isFinite(norm) || norm <= 1e-12) throw new Error('Interest vector has zero or invalid norm');
+  return vector.map(value => value / norm);
+}
+
+// Standard core expansion: border points join one component but never bridge two cores.
+export function weightedDbscan(input: WeightedInterestPoint[]): WeightedInterestPoint[][] {
+  if (input.length > INTEREST_POLICY.maxLabelsPerCategory) throw new Error('Interest category exceeds point limit');
+  const points = input.map(point => ({ ...point, vector: unitVector(point.vector) })).sort(byKey);
+  if (new Set(points.map(point => point.key)).size !== points.length
+    || points.some(point => !Number.isFinite(point.weight) || point.weight <= 0)) throw new Error('Invalid weighted interest samples');
+  // ponytail: O(n² × 1024) per category, hard-capped at 256 points; use a radius index only if this bound grows.
+  const neighbors = points.map((_point, index) => [index]);
+  for (let i = 0; i < points.length; i++) for (let j = i + 1; j < points.length; j++) {
+    if (1 - dot(points[i].vector, points[j].vector) <= INTEREST_POLICY.epsilon + 1e-12) {
+      neighbors[i].push(j); neighbors[j].push(i);
+    }
+  }
+  const core = neighbors.map(indices => indices.reduce((sum, index) => sum + points[index].weight, 0) >= INTEREST_POLICY.minSupport - 1e-9);
+  const assigned = new Set<number>();
+  const clusters: WeightedInterestPoint[][] = [];
+  for (let seed = 0; seed < points.length; seed++) {
+    if (!core[seed] || assigned.has(seed)) continue;
+    const members: number[] = [seed];
+    assigned.add(seed);
+    for (let cursor = 0; cursor < members.length; cursor++) {
+      const current = members[cursor];
+      if (!core[current]) continue;
+      for (const neighbor of neighbors[current]) {
+        if (assigned.has(neighbor)) continue;
+        assigned.add(neighbor); members.push(neighbor);
+      }
+    }
+    clusters.push(members.map(index => points[index]).sort(byKey));
+  }
+  return clusters;
+}
+
+export function interestSamples(videos: InterestVideo[]): Map<string, Sample[]> {
+  if (videos.length > INTEREST_POLICY.maxVideos) throw new Error('Interest video input exceeds limit');
+  const categories = new Map<string, Map<string, { label: string; videos: Map<string, number> }>>();
+  const allowed = new Set(MATCHING_TAXONOMY.topics.map(topic => topic.key));
+  const seenVideos = new Set<string>();
+  for (const video of [...videos].sort((a, b) => b.watchedAt.localeCompare(a.watchedAt) || a.videoId.localeCompare(b.videoId))) {
+    if (seenVideos.has(video.videoId)) continue;
+    seenVideos.add(video.videoId);
+    if (video.status !== 'ready') continue;
+    if (video.tags.length > 15) throw new Error('Interest video exceeds tag limit');
+    const perCategory = new Map<string, Map<string, string>>();
+    for (const tag of video.tags) {
+      if (!allowed.has(tag.categoryKey)) throw new Error('Unknown interest category');
+      const key = normalizeSemanticLabel(tag.label);
+      if (tag.confidence < 0.7 || !key) continue;
+      const labels = perCategory.get(tag.categoryKey) ?? new Map<string, string>();
+      labels.set(key, [labels.get(key) ?? tag.label, tag.label].sort()[0]);
+      perCategory.set(tag.categoryKey, labels);
+    }
+    for (const [category, labels] of perCategory) {
+      const samples = categories.get(category) ?? new Map();
+      for (const [key, label] of labels) {
+        const sample = samples.get(key) ?? { label, videos: new Map<string, number>() };
+        sample.label = [sample.label, label].sort()[0];
+        sample.videos.set(video.videoId, 1 / labels.size);
+        samples.set(key, sample);
+      }
+      categories.set(category, samples);
+    }
+  }
+  return new Map([...categories].sort(([a], [b]) => a.localeCompare(b)).map(([category, samples]) => [category,
+    [...samples].map(([key, sample]) => ({ key, label: sample.label,
+      weight: [...sample.videos.values()].reduce((sum, weight) => sum + weight, 0), videoIds: [...sample.videos.keys()].sort() }))
+      .sort((a, b) => b.weight - a.weight || byKey(a, b)),
+  ]));
+}
+
+export function clusterInterestCategory(categoryKey: string, points: WeightedInterestPoint[], modelContract: string): InterestGroup[] {
+  return weightedDbscan(points).flatMap(members => {
+    const supportingVideoIds = [...new Set(members.flatMap(point => point.videoIds))].sort();
+    if (supportingVideoIds.length < INTEREST_POLICY.minSupport) return [];
+    const centroid = new Array<number>(INTEREST_POLICY.dimensions).fill(0);
+    for (const point of members) point.vector.forEach((value, index) => { centroid[index] += value * point.weight; });
+    if (Math.hypot(...centroid) <= 1e-12) return [];
+    const normalized = unitVector(centroid);
+    const representatives = [...members].sort((a, b) => dot(b.vector, normalized) - dot(a.vector, normalized) || byKey(a, b));
+    return [{ categoryKey, centroid: normalized, mass: members.reduce((sum, point) => sum + point.weight, 0),
+      representativeTags: representatives.slice(0, INTEREST_POLICY.representatives).map(point => point.label),
+      supportingVideoIds, modelContract, algorithmVersion: INTEREST_POLICY.algorithmVersion }];
+  }).sort((a, b) => b.mass - a.mass || JSON.stringify(a.representativeTags).localeCompare(JSON.stringify(b.representativeTags), 'en'))
+    .slice(0, INTEREST_POLICY.maxGroups);
+}
+
+function interestInput(registry: UserRegistry, repository: Repository, client: ReturnType<typeof defaultEmbeddingClient>, tagsContract: string, now: Date) {
+  const modelContract = embeddingContract(client);
+  const window = repository.youtubeInterestWindow(tagsContract,
+    new Date(now.getTime() - INTEREST_POLICY.windowDays * 86400_000).toISOString(), now.toISOString(), INTEREST_POLICY.maxVideos);
+  const samples = interestSamples(window.videos);
+  const selected = new Map([...samples].map(([key, points]) => [key, points.slice(0, INTEREST_POLICY.maxLabelsPerCategory)]));
+  const labels = [...new Set([...selected.values()].flatMap(points => points.map(point => point.key)))].sort();
+  const states = registry.embeddingCacheStates(modelContract, labels);
+  const configured = embeddingsConfigured(client);
+  const inputHash = createHash('sha256').update(JSON.stringify({ policy: INTEREST_POLICY, modelContract, tagsContract, configured,
+    window, vectors: labels.map(label => [label, states.get(label)?.status ?? 'missing']) })).digest('hex');
+  return { modelContract, window, samples, selected, states, configured, inputHash };
+}
+
+export function currentInterests(registry: UserRegistry, repository: Repository, client = defaultEmbeddingClient(), tagsContract = semanticTagContract(), now = new Date()): InterestSnapshot | null {
+  const stored = repository.youtubeInterests();
+  return stored && stored.inputHash === interestInput(registry, repository, client, tagsContract, now).inputHash ? stored : null;
+}
+
+export function buildSemanticInterests(registry: UserRegistry, repository: Repository, client = defaultEmbeddingClient(), tagsContract = semanticTagContract(), now = new Date()): number {
+  const input = interestInput(registry, repository, client, tagsContract, now);
+  if (repository.youtubeInterests()?.inputHash === input.inputHash) return 0;
+  const { modelContract, window, samples, selected, states } = input;
+  const groups: InterestGroup[] = [];
+  const categories: CategoryCoverage[] = [];
+  for (const [categoryKey, chosen] of selected) {
+    const points = chosen.flatMap(point => {
+      const vector = registry.embeddingVector(modelContract, point.key);
+      return vector ? [{ ...point, vector }] : [];
+    });
+    groups.push(...clusterInterestCategory(categoryKey, points, modelContract));
+    const all = samples.get(categoryKey)!;
+    categories.push({ categoryKey, totalLabels: all.length, usedLabels: points.length,
+      totalMass: all.reduce((sum, point) => sum + point.weight, 0), usedMass: points.reduce((sum, point) => sum + point.weight, 0) });
+  }
+  const errors = window.videos.some(video => video.status === 'error') || [...states.values()].some(state => state.status === 'error');
+  const pending = window.videos.some(video => video.status === 'pending')
+    || [...selected.values()].some(points => points.some(point => states.get(point.key)?.status !== 'ready'));
+  const partial = window.total > window.videos.length || categories.some(category => category.usedLabels < category.totalLabels);
+  repository.saveYoutubeInterests({ inputHash: input.inputHash, modelContract, tagsContract,
+    algorithmVersion: INTEREST_POLICY.algorithmVersion, generatedAt: now.toISOString(),
+    validUntil: window.firstExpiryWatch ? new Date(Date.parse(window.firstExpiryWatch) + INTEREST_POLICY.windowDays * 86400_000).toISOString() : null,
+    status: !input.configured ? 'unavailable' : errors ? 'error' : pending ? 'processing' : partial ? 'partial' : 'ready',
+    groups, coverage: { windowVideos: window.total, consideredVideos: window.videos.length,
+      processedVideos: window.videos.filter(video => !['pending', 'error'].includes(video.status)).length,
+      unavailableVideos: window.videos.filter(video => video.status === 'unavailable').length,
+      unidentifiedEvents: window.unidentifiedEvents, categories } });
+  return 1;
+}

--- a/tests/embeddings.test.ts
+++ b/tests/embeddings.test.ts
@@ -106,6 +106,7 @@ test('worker embeds completed tags after partial tag failure and isolates accoun
   const alice = archive(registry, 'failure-alice', ['Failed label']);
   const bob = archive(registry, 'success-bob', ['Successful label']);
   const tagged = new Set<string>();
+  const embedded = new Set<string>();
   const classified = new Set<string>();
   const mocked: EmbeddingClient = { ...client, fetchImpl: async (_url, options) => {
     const request = JSON.parse(String(options?.body));
@@ -123,8 +124,10 @@ test('worker embeds completed tags after partial tag failure and isolates accoun
       },
       embeddings: async (cache, repository, user) => {
         assert.ok(tagged.has(user.handle));
-        return embedSemanticTags(cache, repository, mocked, tagsContract);
+        try { return await embedSemanticTags(cache, repository, mocked, tagsContract); }
+        finally { embedded.add(user.handle); }
       },
+      interests: async (_cache, _repository, user) => { assert.ok(embedded.has(user.handle)); return 1; },
       classification: async (_repository, user) => { classified.add(user.handle); return 1; },
     });
     assert.equal(results.find(result => result.user === bob.user.handle)?.embedded, 1);
@@ -133,6 +136,7 @@ test('worker embeds completed tags after partial tag failure and isolates accoun
     assert.match(failed.error ?? '', /Embedding request/);
     assert.equal(failed.metadata, 2);
     assert.equal(failed.classified, 1);
+    assert.equal(failed.interestsBuilt, 1);
     assert.equal(classified.size, 2);
     assert.equal(youtubeWorkerMadeProgress(results), true);
   } finally { registry.close(); }

--- a/tests/interests.test.ts
+++ b/tests/interests.test.ts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import test from 'node:test';
+import { UserRegistry } from '../src/users.js';
+import type { Repository } from '../src/data/database.js';
+import { embeddingContract, type EmbeddingClient } from '../src/youtube/embeddings.js';
+import { buildSemanticInterests, clusterInterestCategory, currentInterests, interestSamples,
+  INTEREST_POLICY, weightedDbscan, type InterestVideo, type WeightedInterestPoint } from '../src/youtube/interests.js';
+
+const NOW = new Date('2026-09-05T12:00:00Z');
+const client: EmbeddingClient = { baseUrl: 'http://127.0.0.1:8000/v1', apiKey: '', model: 'fixture', revision: 'v1' };
+const modelContract = embeddingContract(client);
+const tagsContract = 'fixture-tags';
+const unit = (axis = 0) => Array.from({ length: 1024 }, (_, index) => Number(index === axis));
+const angle = (degrees: number) => [Math.cos(degrees * Math.PI / 180), Math.sin(degrees * Math.PI / 180), ...Array(1022).fill(0)];
+const video = (id: string, labels = ['Basketball'], watchedAt = '2026-09-01T12:00:00.000Z'): InterestVideo => ({
+  videoId: id, watchedAt, metadataHash: 'hash', status: 'ready', tags: labels.map(label => ({
+    categoryKey: 'sports-fitness', label, source: 'tag', evidence: label, confidence: 0.9,
+  })),
+});
+const point = (key: string, weight: number, vector = unit(), videoIds = ['v1', 'v2', 'v3']): WeightedInterestPoint => ({ key, label: key, weight, vector, videoIds });
+
+function seed(repository: Repository, videos: InterestVideo[]) {
+  repository.ingestYoutubeArchive({ archiveHash: `fixture-${videos.map(item => item.videoId + item.watchedAt).join('-')}`,
+    source: 'takeout', searches: [], watches: videos.map(item => ({
+      eventId: `${item.videoId}-${item.watchedAt}`, videoId: item.videoId, title: 'Public sports fixture',
+      url: `https://www.youtube.com/watch?v=${item.videoId}`, channelId: null, channelTitle: null, channelUrl: null,
+      watchedAt: item.watchedAt, actualWatchedSeconds: 60, activityType: 'video',
+    })) });
+  repository.upsertYoutubeVideoMetadata(videos.map(item => ({ videoId: item.videoId, title: 'Public sports fixture',
+    channelId: null, channelTitle: null, description: '', tags: item.tags.map(tag => tag.label), thumbnailUrl: '',
+    durationSeconds: 60, publishedAt: null, categoryId: '17', availability: 'available', metadataHash: item.metadataHash! })));
+  for (const item of videos) repository.saveYoutubeSemanticTagResult({ videoId: item.videoId,
+    metadataHash: item.metadataHash!, contract: tagsContract, status: 'ready', tags: item.tags, error: null });
+}
+
+function cache(registry: UserRegistry, labels: string[], vector = unit()) {
+  for (const label of labels) {
+    registry.claimEmbedding(modelContract, label, 'fixture-token', '2027-01-01', NOW.toISOString());
+    registry.finishEmbedding(modelContract, label, 'fixture-token', vector, NOW.toISOString(), NOW.toISOString());
+  }
+}
+
+test('weighted DBSCAN preserves core, border and noise without border bridges or input-order effects', () => {
+  const samples = [point('a-core', 3, angle(0)), point('a-edge', 0.4, angle(35)),
+    point('border', 0.1, angle(55)), point('z-core', 3, angle(110)), point('z-edge', 0.4, angle(75)),
+    point('noise', 0.1, angle(180))];
+  const clusters = weightedDbscan(samples).map(group => group.map(item => item.key));
+  assert.deepEqual(clusters, [['a-core', 'a-edge', 'border'], ['z-core', 'z-edge']]);
+  assert.deepEqual(weightedDbscan([...samples].reverse()).map(group => group.map(item => item.key)), clusters);
+  assert.deepEqual(weightedDbscan([]), []);
+  assert.deepEqual(weightedDbscan([point('noise', 2)]), []);
+  assert.throws(() => weightedDbscan([point('bad', 3, [1, 0])]), /dimensions/);
+  assert.throws(() => weightedDbscan([point('bad', 3, Array(1024).fill(0))]), /norm/);
+  assert.throws(() => weightedDbscan(Array.from({ length: 257 }, (_, index) => point(String(index), 1))), /limit/);
+});
+
+test('distinct videos contribute one unit per category, dedupe labels, and yield at most five normalized supported groups', () => {
+  const videos = ['a', 'b', 'c'].map(id => video(id, ['Basketball', 'Shooting', 'basketball']));
+  const samples = interestSamples([...videos, videos[0]]).get('sports-fitness')!;
+  assert.deepEqual(samples.map(item => [item.key, item.weight]), [['basketball', 1.5], ['shooting', 1.5]]);
+  const groups = clusterInterestCategory('sports-fitness', samples.map(item => ({ ...item, vector: unit() })), modelContract);
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0].mass, 3);
+  assert.deepEqual(groups[0].supportingVideoIds, ['a', 'b', 'c']);
+  assert.ok(Math.abs(Math.hypot(...groups[0].centroid) - 1) < 1e-12);
+  assert.deepEqual(interestSamples([...videos].reverse()), interestSamples(videos));
+  const oneVideo = interestSamples([video('solo', ['One', 'Two', 'Three', 'Four', 'Five'])]).get('sports-fitness')!;
+  assert.deepEqual(clusterInterestCategory('sports-fitness', oneVideo.map(item => ({ ...item, vector: unit() })), modelContract), []);
+  assert.deepEqual(clusterInterestCategory('sports-fitness', [point('same-video', 3, unit(), ['one'])], modelContract), []);
+  const separate = Array.from({ length: 6 }, (_, index) => point(`topic-${index}`, 3 + index, unit(index)));
+  const five = clusterInterestCategory('sports-fitness', separate, modelContract);
+  assert.equal(five.length, 5);
+  assert.deepEqual(five.map(group => group.mass), [8, 7, 6, 5, 4]);
+  assert.deepEqual(five, clusterInterestCategory('sports-fitness', separate.reverse(), modelContract));
+  const multi = video('multi', ['Basketball']); multi.tags.push({ ...multi.tags[0], categoryKey: 'learning' });
+  assert.deepEqual([...interestSamples([multi]).values()].map(points => points[0].weight), [1, 1]);
+  assert.throws(() => interestSamples(Array.from({ length: 2001 }, (_, index) => video(String(index)))), /limit/);
+});
+
+test('owner groups persist, export and invalidate on deletion, metadata, expiry and version changes', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'urtube-interests-'));
+  const registryPath = join(directory, 'registry.sqlite');
+  let registry = new UserRegistry(registryPath);
+  try {
+    const owner = registry.createUser('interests-owner', 'Owner');
+    let repository = registry.repositoryFor(owner);
+    const sources = ['one', 'two', 'three'].map(id => video(id));
+    seed(repository, [...sources, video('expired', ['Basketball'], '2026-01-01T00:00:00.000Z'),
+      video('future', ['Basketball'], '2026-12-01T00:00:00.000Z')]);
+    cache(registry, ['basketball']);
+    registry.close();
+    const previous = new DatabaseSync(join(directory, 'users', `${owner.handle}.sqlite`));
+    previous.exec('DROP TABLE youtube_interests; PRAGMA user_version=14;');
+    previous.close();
+    registry = new UserRegistry(registryPath);
+    repository = registry.repositoryFor(registry.userByHandle(owner.handle)!);
+    assert.equal(buildSemanticInterests(registry, repository, client, tagsContract, NOW), 1);
+    const first = currentInterests(registry, repository, client, tagsContract, NOW)!;
+    assert.equal(first.status, 'ready');
+    assert.equal(first.groups[0].mass, 3);
+    assert.deepEqual(first.groups[0].supportingVideoIds, ['one', 'three', 'two']);
+    assert.equal(buildSemanticInterests(registry, repository, client, tagsContract, new Date(NOW.getTime() + 60_000)), 0);
+    assert.equal(currentInterests(registry, repository, { ...client, revision: 'v2' }, tagsContract, NOW), null);
+    assert.equal(currentInterests(registry, repository, client, 'tags-v2', NOW), null);
+    const exported = repository.openPortableExport('fixture-secret-with-at-least-32-characters');
+    assert.equal(exported.tables.find(table => table.source === 'youtube_interests')?.rowCount, 1);
+    exported.close();
+    registry.close(); registry = new UserRegistry(registryPath);
+    repository = registry.repositoryFor(registry.userByHandle(owner.handle)!);
+    assert.equal(currentInterests(registry, repository, client, tagsContract, NOW)?.inputHash, first.inputHash);
+    const writer = new DatabaseSync(join(directory, 'users', `${owner.handle}.sqlite`));
+    writer.prepare('DELETE FROM youtube_watch_events WHERE video_id=?').run('three');
+    writer.close();
+    assert.equal(currentInterests(registry, repository, client, tagsContract, NOW), null);
+    assert.equal(buildSemanticInterests(registry, repository, client, tagsContract, NOW), 1);
+    assert.equal(currentInterests(registry, repository, client, tagsContract, NOW)?.groups.length, 0);
+    seed(repository, sources);
+    buildSemanticInterests(registry, repository, client, tagsContract, NOW);
+    seed(repository, [{ ...sources[0], metadataHash: 'changed' }]);
+    assert.equal(currentInterests(registry, repository, client, tagsContract, NOW), null);
+    buildSemanticInterests(registry, repository, client, tagsContract, NOW);
+    const later = new Date('2026-12-01T00:00:00.000Z');
+    assert.equal(currentInterests(registry, repository, client, tagsContract, later), null);
+    buildSemanticInterests(registry, repository, client, tagsContract, later);
+    assert.equal(currentInterests(registry, repository, client, tagsContract, later)?.groups.length, 0);
+    assert.equal(currentInterests(registry, repository, client, tagsContract, later)?.coverage.windowVideos, 1);
+    registry.deleteUser(owner.handle);
+    assert.equal(registry.listUsers().length, 0);
+  } finally { registry.close(); rmSync(directory, { recursive: true, force: true }); }
+});
+
+test('caps and missing vectors expose coverage instead of inflating the remaining support', () => {
+  const registry = new UserRegistry(':memory:');
+  try {
+    const user = registry.createUser('bounded-owner', 'Bounded');
+    const repository = registry.repositoryFor(user);
+    const sources = Array.from({ length: 257 }, (_, index) => video(`video-${index}`, [`Label ${index}`]));
+    seed(repository, sources);
+    cache(registry, sources.map(item => item.tags[0].label.toLowerCase()));
+    buildSemanticInterests(registry, repository, client, tagsContract, NOW);
+    const snapshot = currentInterests(registry, repository, client, tagsContract, NOW)!;
+    assert.equal(snapshot.status, 'partial');
+    assert.equal(snapshot.coverage.categories[0].totalLabels, 257);
+    assert.equal(snapshot.coverage.categories[0].usedLabels, INTEREST_POLICY.maxLabelsPerCategory);
+    assert.equal(snapshot.coverage.categories[0].usedMass, 256);
+    const missing = registry.repositoryFor(registry.createUser('missing-owner', 'Missing'));
+    seed(missing, ['a', 'b', 'c'].map(id => video(id, ['Known', 'Missing'])));
+    cache(registry, ['known']);
+    buildSemanticInterests(registry, missing, client, tagsContract, NOW);
+    const partial = currentInterests(registry, missing, client, tagsContract, NOW)!;
+    assert.equal(partial.status, 'processing');
+    assert.equal(partial.coverage.categories[0].usedMass, 1.5);
+    assert.equal(partial.groups.length, 0);
+    const bounded = registry.repositoryFor(registry.createUser('video-bound', 'Video bound'));
+    seed(bounded, Array.from({ length: 2001 }, (_, index) => video(`cap-${index}`, [])));
+    buildSemanticInterests(registry, bounded, client, tagsContract, NOW);
+    const cap = currentInterests(registry, bounded, client, tagsContract, NOW)!;
+    assert.equal(cap.status, 'partial');
+    assert.equal(cap.coverage.windowVideos, 2001);
+    assert.equal(cap.coverage.consideredVideos, 2000);
+    const unknown = registry.repositoryFor(registry.createUser('unknown-owner', 'Unknown'));
+    unknown.ingestYoutubeArchive({ archiveHash: 'unidentified', source: 'takeout', searches: [], watches: [{
+      eventId: 'unknown-event', videoId: null, title: 'Deleted video', url: 'https://www.youtube.com/',
+      channelId: null, channelTitle: null, channelUrl: null, watchedAt: NOW.toISOString(),
+      actualWatchedSeconds: null, activityType: 'video',
+    }] });
+    buildSemanticInterests(registry, unknown, client, tagsContract, NOW);
+    const unidentified = currentInterests(registry, unknown, client, tagsContract, NOW)!;
+    assert.equal(unidentified.status, 'ready');
+    assert.equal(unidentified.coverage.windowVideos, 0);
+    assert.equal(unidentified.coverage.unidentifiedEvents, 1);
+  } finally { registry.close(); }
+});

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -143,6 +143,7 @@ test('processing notice counts fall across catch-up cycles and disappear when se
       matchingClassification: async (archive) => classifyYoutubeVideosForMatching(archive, 2),
       semanticTags: async () => 0,
       embeddings: async () => 0,
+      interests: async () => 0,
       classification: async (archive) => {
         const videos = archive.youtubeVideosForPersonalClassification(run, 2);
         for (const video of videos) {
@@ -263,6 +264,7 @@ test('worker stamps each archive and reports pending work only for configured st
       matchingClassification: async () => 0,
       semanticTags: async () => 0,
       embeddings: async () => 0,
+      interests: async () => 0,
       classification: async () => { throw new Error('boom'); },
     };
     await runYoutubeWorkerCycle(registry, steps, () => new Date('2026-09-04T10:00:00Z'));

--- a/tests/registry-crystal.test.ts
+++ b/tests/registry-crystal.test.ts
@@ -203,6 +203,7 @@ test('worker publishes the queued matching crystal after successful processing',
       matchingClassification: async () => 0,
       semanticTags: async () => 0,
       embeddings: async () => 0,
+      interests: async () => 0,
       classification: async () => 0,
     };
     await runYoutubeWorkerCycle(

--- a/tests/user-export.test.ts
+++ b/tests/user-export.test.ts
@@ -130,7 +130,7 @@ test('signed-in owner receives a streamed, readable, privacy-bounded ZIP', async
       files: Array<{ name: string; rowCount: number; fields: unknown[] }>;
       excluded: string[];
     };
-    assert.equal(manifest.schemaVersion, 14);
+    assert.equal(manifest.schemaVersion, 15);
     assert.ok(manifest.files.every((file) => file.fields.length > 0 || file.name === 'matching-crystal.json'));
     for (const file of manifest.files.filter((entry) => entry.name.startsWith('data/'))) {
       assert.equal(readJson(file.name).length, file.rowCount, `${file.name} row count`);

--- a/tests/watch-time.test.ts
+++ b/tests/watch-time.test.ts
@@ -83,7 +83,7 @@ test('version 12 upgrade preserves history and queues available legacy metadata 
     try { assert.deepEqual(upgraded.youtubeVideosNeedingMetadata(), ['LEGACY00001']); }
     finally { upgraded.close(); }
     const migrated = new DatabaseSync(path);
-    assert.equal(migrated.prepare('PRAGMA user_version').get()?.user_version, 14);
+    assert.equal(migrated.prepare('PRAGMA user_version').get()?.user_version, 15);
     assert.equal(migrated.prepare('SELECT title FROM youtube_videos').get()?.title, 'Legacy');
     migrated.close();
   } finally { rmSync(directory, { recursive: true, force: true }); }

--- a/tests/youtube-worker.test.ts
+++ b/tests/youtube-worker.test.ts
@@ -29,6 +29,7 @@ test('YouTube worker enriches every user while keeping portability owner-only', 
       matchingClassification: step('matching'),
       semanticTags: step('semantic'),
       embeddings: async () => 0,
+      interests: async () => 0,
       classification: step('classification'),
     };
 
@@ -73,6 +74,7 @@ test('YouTube worker starts independent user archives concurrently', async () =>
       matchingClassification: async () => 0,
       semanticTags: async () => 0,
       embeddings: async () => 0,
+      interests: async () => 0,
       classification: async () => 0,
     };
 
@@ -106,6 +108,7 @@ test('one user failure is recorded without preventing later users from running',
       matchingClassification: async () => 0,
       semanticTags: async () => 0,
       embeddings: async () => 0,
+      interests: async () => 0,
       classification: async (_repository, user) => {
         classified.push(user.handle);
         return user.handle === bob.handle ? 1 : 0;
@@ -156,6 +159,7 @@ test('a failed semantic batch is isolated from other accounts and private taxono
         return 1;
       },
       embeddings: async () => 0,
+      interests: async () => 0,
       classification: async (_archive, user) => { privateCalls.push(user.handle); return 0; },
     });
     assert.match(results.find(result => result.user === alice.handle)?.error ?? '', /semantic fixture failure/);


### PR DESCRIPTION
Builds owner-only interest groups from distinct videos watched during the last 90 days. Each video contributes one support unit per canonical category, divided across deduplicated tags; missing vectors never inflate the remaining tags. Weighted DBSCAN uses cosine distance, epsilon 0.2 and neighborhood support 3, preserves core/border/noise semantics and fixed-key ordering, then requires three distinct supporting videos per cluster. The five largest normalized weighted centroids per category retain public representative labels and private video evidence.

Processing is bounded to 2000 recent videos and 256 labels per category. Coverage exposes omitted videos/labels/mass, unavailable videos and unidentified Takeout events. Schema 15 stores an owner-only snapshot with model/tag/algorithm contracts and exact input hash; reads invalidate on window, metadata, input, deletion or version changes. The worker rebuilds after embeddings and preserves independent-stage progress.

Validation: `npm run check` passes all 232 tests; independent review approved after fixing null-video events that otherwise stayed pending forever. Tests cover weighted neighborhoods, border bridges, noise, distinct-video weights, multiple groups, deterministic caps, missing-vector coverage, schema 14 upgrade, restart, export, deletion and expiration. No external service or new scoring UI is claimed. The shared matching projection remains #47.

Depends on #57 (stacked branch).

Fixes #46.
