### PR TITLE
Fix compatibility with active matching worker profiles

### DIFF
--- a/docs/matching-v3.md
+++ b/docs/matching-v3.md
@@ -21,6 +21,10 @@
 
 實作於目前的 dev 分支。`MATCHING_V3_ENABLED` 預設關閉：不建立 v3 表、不排程 OpenAI，也不改變原本 `/matches` 的行為。新版入口為 `/matching-v3`，原本 `/match-preview/` 仍是獨立互動原型。
 
+## 現行資料版本相容性
+
+正式 app 與既有 worker 使用相同的 `MATCHING_V3_BACKFILL_VIDEO_LIMIT`（預設 2,000）。取最近觀看的不同影片後，依影片 ID 固定排序；上限納入輪廓版本。bootstrap、排程、重建與讀取共同沿用此設定，避免完成輪廓被誤判為舊版本。此修正不重啟既有 worker，也不清除分類／embedding 快取。
+
 ## 文字與費用限制
 
 分類使用 `gpt-5.6-luna`（API ID 為 luna，不是 lunar），沿用 `src/youtube/ai.ts` 的 `chatJson`：Chat Completions + `response_format=json_object`、`temperature=0`，請求最多 2,048 output tokens；JSON schema 放在文字提示並以 Zod 驗證。相容現有 gateway 沒有 `finish_reason` 的回應及 fenced JSON。影片 payload 僅含 title（最多 1,000 字元）及 tags（最多 30 個，每個最多 100 字元）；頻道 payload 僅含名稱（200 字元）與描述（3,000 字元）。所有 messages.content 都是純文字，沒有圖片、影音、附件、工具或網頁搜尋。Gemini embedding 僅傳每個 tag 的 text part，不包含媒體內容。

--- a/src/data/database.ts
+++ b/src/data/database.ts
@@ -1577,13 +1577,16 @@ export class Repository {
     };
   }
 
-  // Read-only, all available history; DISTINCT prevents replays/rescans from
-  // changing matching weights. No watch timestamps leave this repository.
-  matchingV3Source(): MatchingSourceSnapshot {
-    const rows = this.db.prepare(`SELECT DISTINCT v.video_id, v.title, v.tags_json,
+  // Bound the unique-video source before classification, embedding and channel work.
+  // Watch times remain private; stable ID ordering avoids churn for unchanged membership.
+  matchingV3Source(backfillLimit = 2000): MatchingSourceSnapshot {
+    if (!Number.isSafeInteger(backfillLimit) || backfillLimit < 1) throw new Error('Invalid matching backfill limit');
+    const rows = this.db.prepare(`SELECT v.video_id, v.title, v.tags_json,
       v.description, v.channel_id, v.channel_title
       FROM youtube_videos v JOIN youtube_watch_events w ON w.video_id=v.video_id
-      WHERE w.activity_type='video' ORDER BY v.video_id`).all();
+      WHERE w.activity_type='video' GROUP BY v.video_id
+      ORDER BY MAX(w.watched_at) DESC, v.video_id ASC LIMIT ?`).all(backfillLimit);
+    rows.sort((a, b) => String(a.video_id).localeCompare(String(b.video_id)));
     const videos = rows.map(row => {
       const parsed: unknown = JSON.parse(String(row.tags_json));
       const original = Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : [];

--- a/src/matching-v3/bootstrap.ts
+++ b/src/matching-v3/bootstrap.ts
@@ -14,7 +14,7 @@ export function bootstrapMatching(registry: UserRegistry, s: Settings) {
         topics: [{ id: randomUUID(), name: '探索共同興趣', genres: [...GENRES] }] });
       initialized++;
     }
-    const source = registry.repositoryFor(user).matchingV3Source();
+    const source = registry.repositoryFor(user).matchingV3Source(s.backfillVideoLimit);
     store.schedule(user.id, sourceKey(source.fingerprint, { genres: [...GENRES], topics: [] }), version(s));
     scheduled++;
   }

--- a/src/matching-v3/model.ts
+++ b/src/matching-v3/model.ts
@@ -37,6 +37,7 @@ export function settings(env = process.env) {
     similarityFloor: number('MATCHING_V3_SIMILARITY_FLOOR', 0.7, 0, 0.999),
     computeUrl: env.MATCHING_V3_COMPUTE_URL ?? 'http://matching-compute:8090',
     computeToken: env.MATCHING_V3_COMPUTE_TOKEN ?? '',
+    backfillVideoLimit: (() => { const n = number('MATCHING_V3_BACKFILL_VIDEO_LIMIT', 2000, 1, 1000000); if (!Number.isInteger(n)) throw new Error('Invalid MATCHING_V3_BACKFILL_VIDEO_LIMIT'); return n; })(),
     concurrency: Math.trunc(number('MATCHING_V3_CONCURRENCY', 4, 1, 10000)),
     callsPerCycle: number('MATCHING_V3_CALLS_PER_CYCLE', 20, 0, 100000),
     dailyApiCalls: Math.trunc(number('MATCHING_V3_DAILY_API_CALLS', 200, 0, 100000)),
@@ -45,7 +46,7 @@ export function settings(env = process.env) {
 }
 export function version(s: Settings) {
   return digest(['matching-v3.3-gpt-gemini', 'classification-3-openai-text-only', s.classificationCacheNamespace, s.classificationModel,
-    s.embeddingBaseUrl, s.embeddingModel, s.dimensions, s.task, s.eps, s.minSamples, s.minShare, s.similarityFloor]);
+    s.backfillVideoLimit, s.embeddingBaseUrl, s.embeddingModel, s.dimensions, s.task, s.eps, s.minSamples, s.minShare, s.similarityFloor]);
 }
 export interface VideoInput { id: string; title: string; tags: string[]; channelId: string | null; channelTitle: string | null }
 export interface SourceSnapshot { videos: VideoInput[]; complete: boolean; fingerprint: string }

--- a/src/matching-v3/pipeline.ts
+++ b/src/matching-v3/pipeline.ts
@@ -181,7 +181,7 @@ export async function runCycle(registry: UserRegistry, s: Settings, provider: Pr
   const users = registry.listUsers();
   const allGenres = { genres: [...GENRES], topics: [] };
   for (const user of users) {
-    const source = registry.repositoryFor(user).matchingV3Source();
+    const source = registry.repositoryFor(user).matchingV3Source(s.backfillVideoLimit);
     store.schedule(user.id, sourceKey(source.fingerprint, allGenres), version(s));
   }
   let calls = 0;
@@ -206,7 +206,7 @@ export async function runCycle(registry: UserRegistry, s: Settings, provider: Pr
     try {
       const user = users.find(u => u.id === job.userId);
       if (!user) { store.defer(job, 'User no longer opted in', true); continue; }
-      const source = registry.repositoryFor(user).matchingV3Source();
+      const source = registry.repositoryFor(user).matchingV3Source(s.backfillVideoLimit);
       if (sourceKey(source.fingerprint, allGenres) !== job.fingerprint) {
         store.schedule(user.id, sourceKey(source.fingerprint, allGenres), version(s));
         continue;
@@ -219,7 +219,7 @@ export async function runCycle(registry: UserRegistry, s: Settings, provider: Pr
         calls++;
       }, value => store.progress(job, value));
       const currentUser = registry.listUsers().find(u => u.id === user.id);
-      const current = registry.repositoryFor(user).matchingV3Source();
+      const current = registry.repositoryFor(user).matchingV3Source(s.backfillVideoLimit);
       if (!currentUser || sourceKey(current.fingerprint, allGenres) !== job.fingerprint) {
         if (currentUser) store.schedule(user.id, sourceKey(current.fingerprint, allGenres), version(s));
         else store.defer(job, 'user_deleted', true);

--- a/src/matching-v3/routes.ts
+++ b/src/matching-v3/routes.ts
@@ -56,7 +56,7 @@ export function matchingRoutes(registry: UserRegistry, s: Settings, origin: stri
         profile: p ? { builtAt: p.builtAt, totalVideos: p.totalVideos, processedVideos: p.processedVideos,
           genres: Object.fromEntries(Object.entries(p.genres).map(([genre, value]) => [genre, { status: value.status }])) } : null };
     });
-    return c.json({ ...store.monitoring(), now: Date.now(), dailyLimit: s.dailyApiCalls, concurrency: s.concurrency, batchSize: s.classificationBatchSize, classificationModel: s.classificationModel, reasoningEffort: 'low', genres: GENRES, users });
+    return c.json({ ...store.monitoring(), now: Date.now(), backfillVideoLimit: s.backfillVideoLimit, dailyLimit: s.dailyApiCalls, concurrency: s.concurrency, batchSize: s.classificationBatchSize, classificationModel: s.classificationModel, reasoningEffort: 'low', genres: GENRES, users });
   });
   app.post('/api/matching-v3/admin/retry/:id', c => {
     const id = Number(c.req.param('id'));
@@ -93,7 +93,7 @@ export function matchingRoutes(registry: UserRegistry, s: Settings, origin: stri
   app.post('/api/matching-v3/rebuild', c => {
     const user = c.get('user'), prefs = store.preferences(user.id);
     if (!user.matchingOptIn || !prefs.genres.length) return c.json({ error: 'opt_in_required' }, 403);
-    const source = registry.repositoryFor(user).matchingV3Source();
+    const source = registry.repositoryFor(user).matchingV3Source(s.backfillVideoLimit);
     store.schedule(user.id, sourceKey(source.fingerprint, { genres: [...GENRES], topics: [] }), version(s));
     store.retry(user.id);
     return c.json({ queued: true }, 202);

--- a/tests/matching-v3.test.ts
+++ b/tests/matching-v3.test.ts
@@ -13,6 +13,15 @@ import { normalizeYoutubeCapture } from '../src/youtube/capture.js';
 import { compareProfiles } from '../src/matching-v3/matching.js';
 
 const s = settings({ MATCHING_V3_ENABLED: 'true' });
+
+test('v3 profile version stays compatible with the deployed bounded worker', () => {
+  assert.equal(s.backfillVideoLimit, 2000);
+  assert.equal(version(s), '20376b513a2150fb5899e999bd53812dc9c3dae98b4ce7b8849c27477f276d88');
+  assert.notEqual(version({ ...s, backfillVideoLimit: 1000 }), version(s));
+  for (const value of ['0', '-1', '2.5', '1000001', 'invalid']) {
+    assert.throws(() => settings({ MATCHING_V3_BACKFILL_VIDEO_LIMIT: value }), /BACKFILL_VIDEO_LIMIT/);
+  }
+});
 const video: VideoInput = { id: 'testvideo01', title: '羽球練習', tags: ['羽球'], channelId: 'UC-test', channelTitle: 'Test' };
 const classification: Classification = { tagSource: 'original', tags: ['羽球'], assignments: [{ genre: 'Sport', tags: ['羽球', '羽球'] }] };
 const compute: Compute = {
@@ -248,6 +257,35 @@ test('v3 worker resumes within budget and source fingerprint ignores replay watc
     assert.equal(repo.matchingV3Source().complete, true);
     scan('v3-interrupted-scan-fixture', '2026-09-05T14:00:00Z', 'time-limit');
     assert.equal(repo.matchingV3Source().complete, false);
+  } finally { registry.close(); }
+});
+
+test('v3 source and worker apply the same recent unique-video limit without replay churn', async () => {
+  const registry = new UserRegistry(':memory:');
+  try {
+    const user = registry.createUser('boundedfixture', 'Bounded Fixture'), repo = registry.repositoryFor(user);
+    let session = 0;
+    const capture = (id: string, hour: number) => repo.upsertYoutubeCapture(normalizeYoutubeCapture({
+      sessionId: `bounded-fixture-session-${++session}`, videoId: id, title: '羽球 #羽球',
+      url: `https://www.youtube.com/watch?v=${id}`, watchedAt: `2026-09-04T${hour}:00:00Z`,
+      actualWatchedSeconds: 30, durationSeconds: 60,
+    }, new Date('2026-09-05T12:00:00Z')));
+    capture('LIMITTEST01', 10); capture('LIMITTEST02', 11); capture('LIMITTEST03', 12);
+    const first = repo.matchingV3Source(2);
+    assert.deepEqual(first.videos.map(v => v.id), ['LIMITTEST02', 'LIMITTEST03']);
+    capture('LIMITTEST02', 13);
+    assert.equal(repo.matchingV3Source(2).fingerprint, first.fingerprint);
+    const classified: string[] = [];
+    const provider: Provider = {
+      classify: async v => { classified.push(v.id); return classification; },
+      embed: async () => [[1, 0]], channel: async () => ({ types: [], evidenceAvailable: false }),
+    };
+    await runCycle(registry, { ...s, backfillVideoLimit: 2 }, provider, compute);
+    assert.deepEqual(classified.sort(), ['LIMITTEST02', 'LIMITTEST03']);
+    assert.equal(registry.matchingV3Store().profile(user.id)?.totalVideos, 2);
+    capture('LIMITTEST01', 14);
+    assert.notEqual(repo.matchingV3Source(2).fingerprint, first.fingerprint);
+    assert.deepEqual(repo.matchingV3Source(2).videos.map(v => v.id), ['LIMITTEST01', 'LIMITTEST02']);
   } finally { registry.close(); }
 });
 


### PR DESCRIPTION
Production validation after #64 found that the active matching worker already includes the per-user backfill limit in its profile version, while the merged app did not. The app consequently treated completed worker profiles as pending.

Align settings, profile version, and source selection with that existing worker: the default is the 2,000 most recently watched unique videos, with stable ID ordering. Bootstrap, worker scheduling, and explicit rebuilds use the same limit. Preserve the integrated named profiles, friendship controls, visibility rules, classification caches, and running worker.

Validation: typecheck and all 285 Node tests passed with no skips, including the Python HTTP fixture. Added regressions for the deployed profile version, configuration validation, bounded worker inputs, and replay-stable fingerprints. Docker image built successfully.
