### PR TITLE
Recover matching backup branch after history rewrite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,3 +94,9 @@ MATCHING_V3_CONCURRENCY=4
 # Optional stable classification cache identity when explicitly preserving
 # existing results during an endpoint switch. Defaults to current base URL.
 # MATCHING_V3_CLASSIFICATION_CACHE_NAMESPACE=
+
+# Latest distinct watched videos per account for matching backfill.
+MATCHING_V3_BACKFILL_VIDEO_LIMIT=2000
+
+# Optional dedicated comparison service; leave empty to use MATCHING_V3_COMPUTE_URL.
+# MATCHING_V3_COMPARE_URL=http://matching-compare:8090

--- a/compose.matching-v3.yml
+++ b/compose.matching-v3.yml
@@ -9,9 +9,20 @@ services:
     environment:
       MATCHING_V3_ENABLED: "true"
       MATCHING_V3_COMPUTE_URL: http://matching-compute:8090
+      MATCHING_V3_COMPARE_URL: http://matching-compare:8090
     depends_on:
       matching-compute:
         condition: service_started
+      matching-compare:
+        condition: service_started
+  matching-compare:
+    build: ./services/matching-compute
+    image: urtube-matching-compute:dev
+    restart: unless-stopped
+    env_file: .env.matching-v3
+    mem_limit: 1g
+    cpus: 1
+    # Dedicated comparison process; no background cluster jobs are routed here.
   matching-compute:
     build: ./services/matching-compute
     image: urtube-matching-compute:dev

--- a/docs/matching-v3.md
+++ b/docs/matching-v3.md
@@ -244,3 +244,63 @@ Gemini 依使用者最新要求不設本機並行上限。
 每次 event-loop turn 派送最多 32 個新操作，再以 setImmediate 讓網路回應及心跳執行，
 沒有固定毫秒等待或 RPM 節流。监控紀錄清理每 256 個新操作執行一次，保留最近五分鐘的
 完成紀錄及所有執行中紀錄，減少 SQLite 同步工作阻塞請求回應。
+
+### 2026-09-06 備份檢查
+
+新增 Gemini key 後輪換池共六把（秘密值僅放 ignored env）。
+確認 dev matching worker、正式 app、backup 都掛載 `urtube_urtube-data`。
+完整備份：`/home/deck/Backups/urtube/nightly/manual-matching-2026-09-06-six-keys`。
+備份完成時間 2026-09-06 00:03:55（Asia/Taipei），16 位使用者、17 個 SQLite 檔，
+合計 1,636,806,656 bytes；registry 快照含 183,478 筆 matching cache。
+專案備份工具對每個輸出檔執行 integrity_check 並保存 SHA-256 manifest；
+這是同主機備份，尚未執行還原演練或建立異地副本。
+
+### Backfill 影片範圍上限
+
+`MATCHING_V3_BACKFILL_VIDEO_LIMIT=2000`（預設）：每位使用者依最後觀看時間，
+只取最新 2000 部不同影片，所有種類合計，非每類 2000 部。相同時間用影片 ID 穩定排序。
+分類、tag embedding、頻道分析與最終 profile 共用此來源；worker、bootstrap、手動 rebuild
+皆套用同一設定。上限必須為正整數。這限制來源影片數，並非 API RPM 或 tag 數上限。
+調整上限會使 profile 重新聚合，但不清除原始歷史或成功分類／embedding 快取；
+範圍外快取保留供之後使用。profile.totalVideos 表示這次受限範圍的影片數，
+complete 仍表示來源掃描完整性，不代表整段歷史全部納入 matching。
+
+### 暫定測試輪廓
+
+`publishCachedPreviews` 從每人最新 2000 部（依 backfill 設定）中已提交的分類、tag 向量
+建立暫定輪廓，不呼叫 GPT/Gemini，不補假向量；缺少向量的 tag 不參與叢集。
+所有類別標示 insufficient、整份 complete=false，配對既有 provisional 邏輯會標示暫定。
+只建立有實際叢集的輪廓，不覆蓋目前版本輪廓、不改工作狀態、不擴大配對公開同意。
+背景原工作繼續補全，最終結果仍由原子 finish 發布。此工具用於開發預覽，
+不可把暫定比例／分數當作完整 2000 部的最終分布。
+
+### 配對身分與公開條件
+
+歷史分支的「只列出公開 profile」限制與本討論串衝突，整合時沿用正式站規則：
+候選須開啟 matchingOptIn 並同意所有選定類別；私密成員仍能出現身分、合拍度與好友按鈕。
+詳細理由與 tags 僅對好友或公開 profile 顯示，完成所有非同步計算後重新驗證授權。
+API 沿用 handle、displayName、detailsVisible、memberHtml，頭像經既有 avatar 路由；
+不回傳 email、密鑰或原始觀看資料。首頁成員展示仍只列出公開 profile。
+
+### 即時配對計算隔離
+
+cluster 由背景 worker 計算後存入 matching_v3_profiles；點擊配對不呼叫 GPT/Gemini，
+也不重新分群，只比較已儲存的 cluster 質心及權重。
+`MATCHING_V3_COMPARE_URL` 可指定獨立即時比較服務；未指定則相容原 computeUrl。
+開發部署以 matching-compare 容器處理 compare，原 matching-compute 專做背景分群，
+避免 Python 單執行緒 HTTPServer 讓即時配對排在大批次 DBSCAN 後面。
+
+### 配對延遲與 502 修正
+
+監控快取分類统计使用 expression index，避免每五秒解析／掃描整張向量快取表。
+單 cluster 對單 cluster 使用與 1x1 transport 相同的 cosine／floor 公式直接計算；
+多 cluster 仍走獨立 compare 服務。前端對空白或非 JSON 的 HTTP 錯誤提供可讀訊息。
+2026-09-06 修正後在背景 worker 恢復狀態，經 Caddy 實測 Music+Sport 兩次
+HTTP 200，60ms／20ms，各回傳 7 位公開候選（僅為當次量測，不是延遲保證）。
+
+### 歷史修復（2026-09-06）
+
+`feature/dev-matching-local-backup-20260906` 的舊祖先已由 #64、#65、#67 等整合。
+本次從最新 main 接回尚未合併的監控索引、獨立 compare、暫定快取輪廓與 HTTP 錯誤處理；
+保留正式 `/matches`、Profile／好友／Blend 可見性，以及 `/landing-assets/` 與站內相對連結。
+不把歷史分支的匿名／僅公開帳號列表及開發用圖片路徑帶回正式站。

--- a/src/matching-v3/admin.js
+++ b/src/matching-v3/admin.js
@@ -15,7 +15,7 @@ function renderUsers() {
     if (user.profile) {
       profile.append(node('small', `${number(user.profile.processedVideos)} / ${number(user.profile.totalVideos)} 部影片 · ${user.currentVersion ? '目前版本' : '舊版本'}`));
       const detail = node('details'); detail.append(node('summary', '查看九類狀態'));
-      for (const genre of data.genres) detail.append(node('small', `${genre}：${labels[user.profile.genres[genre]?.status] || '尚未建立'}`));
+      for (const genre of data.genres) detail.append(node('small', `${genre}：${labels[user.profile.genres[genre]?.status] || '尚未建立'} · ${user.profile.genres[genre]?.clusterCount ?? 0} 個 cluster`));
       profile.append(detail, node('small', `建立於 ${date(user.profile.builtAt)}`));
     }
     const error = node('div', `${job?.attempts || 0} 次失敗`);
@@ -39,7 +39,7 @@ function render() {
     ['尚待完成工作', data.users.filter(u => u.job?.state !== 'done').length, '包含排程、處理中與失敗'],
   ]) { const card = node('div', label, 'card'); card.append(node('strong', number(value), 'value'), node('small', note)); $('cards').append(card); }
   const fresh = data.heartbeat && data.now - data.heartbeat < 60000;
-  $('worker').textContent = `Worker：${fresh ? '心跳正常' : '尚無近期心跳，請檢查服務'} · 最後心跳 ${date(data.heartbeat)} · ${data.concurrency} 個並行工作 · 分類最多 ${data.batchSize} 部／批 · 請求模型 ${data.classificationModel} / effort ${data.reasoningEffort}`;
+  $('worker').textContent = `Worker：${fresh ? '心跳正常' : '尚無近期心跳，請檢查服務'} · 最後心跳 ${date(data.heartbeat)} · ${data.concurrency} 個並行工作 · 每人 backfill 最新 ${number(data.backfillVideoLimit || 2000)} 部 · 分類最多 ${data.batchSize} 部／批 · 請求模型 ${data.classificationModel} / effort ${data.reasoningEffort}`;
   $('worker').className = fresh ? 'good' : 'warn';
   $('budget').textContent = `今日操作 ${number(data.budget.calls)} · ${data.dailyLimit ? `每日上限 ${number(data.dailyLimit)}` : '目前未設每日上限（暫時開放）'} · 日界線為台灣時間上午 8 點`;
   $('providers').replaceChildren();

--- a/src/matching-v3/client.js
+++ b/src/matching-v3/client.js
@@ -21,8 +21,9 @@ $('mv-invites').onclick = () => { requestNumber++; selectedId = null; showView('
 const messages = { login_required: '登入已過期，請重新登入。', opt_in_required: '請先在「我的帳號」開啟參與配對。', profile_pending: '興趣輪廓尚未建立，請等待背景處理完成。', profile_changed: '輪廓剛更新，請重新配對。', matching_unavailable: '配對服務暫時無法使用，請稍後再試。', matching_in_progress: '配對仍在計算中。' };
 async function api(path = '', method = 'GET', body) {
   const response = await fetch('/api/matching-v3' + path + '?lang=' + lang, { method, headers: body ? { 'Content-Type': 'application/json' } : {}, body: body ? JSON.stringify(body) : undefined });
-  const data = await response.json();
-  if (!response.ok) throw new Error(messages[data.error] || '操作未完成，請稍後再試。');
+  const data = await response.json().catch(() => null);
+  if (!response.ok) throw new Error(messages[data?.error] || `服務暫時無法回應（HTTP ${response.status}），請稍後重試。`);
+  if (!data) throw new Error('服務回應不完整，請重新嘗試配對。');
   return data;
 }
 function error(err) { showView('topics'); $('message').textContent = err.message; $('message').className = 'error'; }
@@ -34,7 +35,7 @@ async function load() {
     const link = element('a', '我的帳號'); link.href = '/account'; $('status').append(link, element('span', ' 開啟參與配對，再選擇興趣。'));
   } else {
     const profile = state.profile;
-    $('status').append(element('span', profile ? `已建立 ${profile.processedVideos.toLocaleString()} 部不同影片的輪廓 · ${profile.complete ? '已有完整掃描紀錄' : '掃描覆蓋尚未完整，配對為暫定'}${profile.currentVersion ? '' : ' · 演算法更新中'}` : '正在預先建立所有類別的配對輪廓，不需要先選擇興趣。'));
+    $('status').append(element('span', profile ? `已建立 ${profile.processedVideos.toLocaleString()} 部不同影片的輪廓 · ${profile.complete ? '已有完整掃描紀錄' : '資料尚未齊全，配對為暫定'}${profile.currentVersion ? '' : ' · 演算法更新中'}` : '正在預先建立所有類別的配對輪廓，不需要先選擇興趣。'));
     if (state.job) $('status').append(element('p', `處理狀態：${({ queued: '排程中', running: '處理中', done: '完成', failed: '需重試' })[state.job.state] || state.job.state}`, 'small muted'));
     if (state.job?.progress && state.job.state !== 'done') {
       const p = state.job.progress;

--- a/src/matching-v3/compute.ts
+++ b/src/matching-v3/compute.ts
@@ -6,7 +6,7 @@ export interface Compute {
 }
 export function computeClient(s: Settings): Compute {
   async function call<T>(path: string, body: unknown): Promise<T> {
-    const response = await fetch(`${s.computeUrl}${path}`, {
+    const response = await fetch(`${path === '/compare' && s.compareUrl ? s.compareUrl : s.computeUrl}${path}`, {
       method: 'POST', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${s.computeToken}` },
       body: JSON.stringify(body), signal: AbortSignal.timeout(120_000),
     });
@@ -15,6 +15,21 @@ export function computeClient(s: Settings): Compute {
   }
   return {
     cluster: points => call('/cluster', { points, eps: s.eps, minSamples: s.minSamples, minShare: s.minShare }),
-    compare: (left, right) => call('/compare', { left: left.clusters, right: right.clusters, similarityFloor: s.similarityFloor }),
+    compare: async (left, right) => {
+      if (!left.clusters.length || !right.clusters.length) return { score: 0, transport: [] };
+      // A 1x1 transport matrix has exactly one feasible flow (mass=1).
+      // Identical to the solver, without HTTP/LP startup for the common case.
+      if (left.clusters.length === 1 && right.clusters.length === 1) {
+        const a = left.clusters[0], b = right.clusters[0];
+        const na = Math.hypot(...a.centroid), nb = Math.hypot(...b.centroid);
+        if (a.share === 1 && b.share === 1 && a.centroid.length === b.centroid.length
+          && na > 0 && nb > 0 && Number.isFinite(na) && Number.isFinite(nb)) {
+          const cosine = a.centroid.reduce((sum, value, i) => sum + (value / na) * (b.centroid[i] / nb), 0);
+          const score = Math.min(1, Math.max(0, (cosine - s.similarityFloor) / (1 - s.similarityFloor)));
+          return { score, transport: [{ left: 0, right: 0, mass: 1, similarity: score, contribution: score }] };
+        }
+      }
+      return call('/compare', { left: left.clusters, right: right.clusters, similarityFloor: s.similarityFloor });
+    },
   };
 }

--- a/src/matching-v3/model.ts
+++ b/src/matching-v3/model.ts
@@ -36,6 +36,7 @@ export function settings(env = process.env) {
     minShare: number('MATCHING_V3_MIN_SHARE', 0.05, 0, 1),
     similarityFloor: number('MATCHING_V3_SIMILARITY_FLOOR', 0.7, 0, 0.999),
     computeUrl: env.MATCHING_V3_COMPUTE_URL ?? 'http://matching-compute:8090',
+    compareUrl: env.MATCHING_V3_COMPARE_URL ?? '',
     computeToken: env.MATCHING_V3_COMPUTE_TOKEN ?? '',
     backfillVideoLimit: (() => { const n = number('MATCHING_V3_BACKFILL_VIDEO_LIMIT', 2000, 1, 1000000); if (!Number.isInteger(n)) throw new Error('Invalid MATCHING_V3_BACKFILL_VIDEO_LIMIT'); return n; })(),
     concurrency: Math.trunc(number('MATCHING_V3_CONCURRENCY', 4, 1, 10000)),

--- a/src/matching-v3/preview.ts
+++ b/src/matching-v3/preview.ts
@@ -1,0 +1,51 @@
+import type { UserRegistry } from '../users.js';
+import type { Compute } from './compute.js';
+import { CONTENT_GENRES, version, type Classification, type Profile, type Settings, type SourceSnapshot, type TagPoint } from './model.js';
+import { aggregateTags, classificationKey, embeddingKey } from './pipeline.js';
+import type { MatchingStore } from './store.js';
+
+// No provider calls: preview uses only committed cache from the bounded source.
+export async function cachedPreview(source: SourceSnapshot, store: MatchingStore, s: Settings, compute: Compute): Promise<Profile> {
+  const classifications = new Map<string, Classification>();
+  for (const video of source.videos) {
+    const value = store.cache<Classification>(classificationKey(s, video));
+    if (value) classifications.set(video.id, value);
+  }
+  const genres: Profile['genres'] = {};
+  for (const genre of CONTENT_GENRES) {
+    const { tags, videoCount } = aggregateTags(source.videos, classifications, genre);
+    const points: TagPoint[] = [];
+    let expectedMass = 0;
+    for (const [text, counts] of tags) {
+      expectedMass += counts.count;
+      const vector = store.cache<number[]>(embeddingKey(s, text));
+      if (vector) points.push({ text, ...counts, vector });
+    }
+    if (!points.length || points.length > 10000) continue;
+    const result = await compute.cluster(points);
+    const availableMass = points.reduce((sum, point) => sum + point.count, 0);
+    genres[genre] = { ...result, videoCount, status: 'insufficient',
+      retainedCoverage: expectedMass ? result.retainedCoverage * availableMass / expectedMass : 0 };
+  }
+  return { version: version(s), sourceFingerprint: source.fingerprint, builtAt: new Date().toISOString(),
+    complete: false, totalVideos: source.videos.length, processedVideos: classifications.size, genres };
+}
+
+export async function publishCachedPreviews(registry: UserRegistry, s: Settings, compute: Compute) {
+  const store = registry.matchingV3Store();
+  let published = 0, skipped = 0;
+  for (const user of registry.listUsers()) {
+    const current = registry.listUsers().find(candidate => candidate.id === user.id);
+    if (!current) { skipped++; continue; }
+    const previous = store.profile(current.id);
+    if (previous?.version === version(s)) { skipped++; continue; }
+    const source = registry.repositoryFor(current).matchingV3Source(s.backfillVideoLimit);
+    const profile = await cachedPreview(source, store, s, compute);
+    const fresh = registry.listUsers().find(candidate => candidate.id === current.id);
+    if (!fresh || fresh.handle !== current.handle) { skipped++; continue; }
+    if (!Object.values(profile.genres).some(g => g.clusters.length)
+      || registry.repositoryFor(fresh).matchingV3Source(s.backfillVideoLimit).fingerprint !== source.fingerprint) { skipped++; continue; }
+    if (store.publishPreview(fresh.id, profile, previous)) published++; else skipped++;
+  }
+  return { published, skipped };
+}

--- a/src/matching-v3/routes.ts
+++ b/src/matching-v3/routes.ts
@@ -54,7 +54,7 @@ export function matchingRoutes(registry: UserRegistry, s: Settings, origin: stri
       return { id: user.id, handle: user.handle, job: store.status(user.id), currentVersion,
         usable: Boolean(currentVersion && p && Object.values(p.genres).some(g => g.status === 'ready')),
         profile: p ? { builtAt: p.builtAt, totalVideos: p.totalVideos, processedVideos: p.processedVideos,
-          genres: Object.fromEntries(Object.entries(p.genres).map(([genre, value]) => [genre, { status: value.status }])) } : null };
+          genres: Object.fromEntries(Object.entries(p.genres).map(([genre, value]) => [genre, { status: value.status, clusterCount: value.clusters.length }])) } : null };
     });
     return c.json({ ...store.monitoring(), now: Date.now(), backfillVideoLimit: s.backfillVideoLimit, dailyLimit: s.dailyApiCalls, concurrency: s.concurrency, batchSize: s.classificationBatchSize, classificationModel: s.classificationModel, reasoningEffort: 'low', genres: GENRES, users });
   });

--- a/src/matching-v3/store.ts
+++ b/src/matching-v3/store.ts
@@ -19,6 +19,10 @@ export class MatchingStore {
       CREATE TABLE IF NOT EXISTS matching_v3_cache (
         key TEXT PRIMARY KEY, value_json TEXT NOT NULL, created_at INTEGER NOT NULL
       );
+      CREATE INDEX IF NOT EXISTS matching_v3_cache_stats ON matching_v3_cache (
+        CASE WHEN json_type(value_json)='array' THEN 'embedding'
+          WHEN json_type(value_json,'$.assignments')='array' THEN 'classification' ELSE 'channel' END,
+        created_at);
       CREATE TABLE IF NOT EXISTS matching_v3_api_budget (
         day TEXT PRIMARY KEY, calls INTEGER NOT NULL
       );
@@ -130,6 +134,18 @@ export class MatchingStore {
   heartbeat(job: Job): void {
     const result = this.db.prepare("UPDATE matching_v3_jobs SET lease_until=? WHERE user_id=? AND token=? AND state='running'").run(Date.now() + 180_000, job.userId, job.token);
     if (!result.changes) throw new Error('Job superseded');
+  }
+  publishPreview(userId: number, profile: Profile, previous: Profile | null): boolean {
+    if (profile.complete) throw new Error('Preview must be provisional');
+    // Publish only if the exact state observed before async clustering still holds.
+    // A worker can publish a different version while a preview is being built.
+    const result = previous === null
+      ? this.db.prepare(`INSERT INTO matching_v3_profiles(user_id,profile_json) VALUES (?,?)
+          ON CONFLICT(user_id) DO NOTHING`).run(userId, JSON.stringify(profile))
+      : this.db.prepare(`UPDATE matching_v3_profiles SET profile_json=?
+          WHERE user_id=? AND profile_json=? AND json_extract(profile_json,'$.version') != ?`)
+        .run(JSON.stringify(profile), userId, JSON.stringify(previous), profile.version);
+    return Boolean(result.changes);
   }
   finish(job: Job, profile: Profile): boolean {
     this.db.exec('BEGIN IMMEDIATE');

--- a/tests/matching-client-errors.test.ts
+++ b/tests/matching-client-errors.test.ts
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+
+for (const [status, body, expected] of [
+  [502, '', /HTTP 502/],
+  [503, '<html>Service unavailable</html>', /HTTP 503/],
+  [200, '', /服務回應不完整/],
+  [401, '{"error":"login_required"}', /登入已過期/],
+] as const) test(`matching UI handles HTTP ${status} with a readable error`, async () => {
+  const source=readFileSync(new URL('../src/matching-v3/client.js',import.meta.url),'utf8').split('function error(err)')[0];
+  const context={
+    document: { documentElement: { lang: 'zh' }, getElementById: () => ({}) },
+    fetch:async()=>new Response(body,{status}),run:null as null|(()=>Promise<unknown>)
+  };
+  runInNewContext(source+'\nglobalThis.run=api;',context);
+  await assert.rejects(context.run!(),expected);
+});

--- a/tests/matching-v3.test.ts
+++ b/tests/matching-v3.test.ts
@@ -190,7 +190,7 @@ test('v3 Gemini missing key does not fall back to GPT; malformed vectors are rej
 test('v3 API enforces authentication, origin, genre consent and member detail visibility', async () => {
   const registry = new UserRegistry(':memory:');
   try {
-    registry.createUser('v3left', 'Left'); registry.createUser('v3right', 'Right');
+    registry.createUser('v3left', 'Left'); registry.createUser('v3right', 'Right', { googleEmail: 'private@example.com' });
     registry.setMatchingOptIn('v3left', true); registry.setMatchingOptIn('v3right', true);
     const left = registry.userByHandle('v3left')!, right = registry.userByHandle('v3right')!;
     const store = registry.matchingV3Store();
@@ -206,7 +206,7 @@ test('v3 API enforces authentication, origin, genre consent and member detail vi
     assert.equal((await post(['Custom'])).status, 400);
     assert.equal((await post(['Music'])).status, 403);
     const response = await post(['Sport']); assert.equal(response.status, 200);
-    const body = await response.text(); assert.ok(!/centroid|testvideo01|羽球/.test(body));
+    const body = await response.text(); assert.ok(!/centroid|testvideo01|羽球|private@example.com|googleEmail|keySeed/.test(body));
     assert.equal(JSON.parse(body).candidates[0].handle, 'v3right');
     assert.deepEqual(JSON.parse(body).candidates[0].reasons, []);
     assert.equal(JSON.parse(body).candidates.length, 1);
@@ -622,4 +622,100 @@ test('v3 Gemini dispatch is not blocked by a saturated GPT queue', async () => {
     await Promise.race([second, new Promise((_, reject) => { timer = setTimeout(() => reject(new Error('Gemini blocked behind GPT')), 1000); })]);
     assert.equal(embedded, true);
   } finally { clearTimeout(timer); release(); await Promise.allSettled([first, ...(second ? [second] : [])]); db.close(); }
+});
+
+test('cached preview uses real vectors only, stays provisional and preserves background job', async () => {
+  const { cachedPreview } = await import('../src/matching-v3/preview.js');
+  const { classificationKey, embeddingKey } = await import('../src/matching-v3/pipeline.js');
+  const { db, store } = storeFixture();
+  try {
+    store.putCache(classificationKey(s, video), { tagSource: 'original', tags: ['ready','pending'], assignments: [{ genre:'Sport', tags:['ready','pending'] }] });
+    store.putCache(embeddingKey(s,'ready'), [1,0]);
+    store.schedule(1,'original-job',version(s));
+    const before = store.status(1);
+    const p = await cachedPreview({ videos:[video], complete:true, fingerprint:'bounded' },store,s,compute);
+    assert.equal(p.complete,false);
+    assert.equal(p.genres.Sport?.retainedCoverage,0.5);
+    assert.equal(p.genres.Sport?.status,'insufficient');
+    assert.equal(p.genres.Sport?.clusters.length,1);
+    assert.equal(store.publishPreview(1,p,null),true);
+    assert.deepEqual(store.status(1),before);
+    assert.equal(store.publishPreview(1,{...p,builtAt:'replacement'},p),false);
+    const result=await compareProfiles(p,p,['Sport'],compute);
+    assert.equal(result.provisional,true);
+    assert.notEqual(result.score,null);
+  } finally { db.close(); }
+});
+
+test('cached preview cannot replace a worker result published during clustering', () => {
+  const { db, store } = storeFixture();
+  try {
+    const previous = { ...profile(), version: 'old-profile' };
+    store.schedule(1, 'old', previous.version); store.finish(store.claim()!, previous);
+    const observed = store.profile(1);
+    const newer = { ...profile(), version: 'new-worker-version', builtAt: '2026-09-06T01:00:00Z' };
+    store.schedule(1, 'new', newer.version); store.finish(store.claim()!, newer);
+    const preview = { ...profile(), complete: false };
+    assert.equal(store.publishPreview(1, preview, observed), false);
+    assert.equal(store.publishPreview(1, preview, null), false);
+    assert.deepEqual(store.profile(1), newer);
+  } finally { db.close(); }
+});
+
+for (const action of ['delete', 'rename'] as const) test(`cached preview skips a user ${action}d during clustering`, async () => {
+  const { publishCachedPreviews } = await import('../src/matching-v3/preview.js');
+  const { classificationKey, embeddingKey } = await import('../src/matching-v3/pipeline.js');
+  const registry = new UserRegistry(':memory:');
+  try {
+    const user = registry.createUser('previewfixture', 'Preview Fixture');
+    const repo = registry.repositoryFor(user), store = registry.matchingV3Store();
+    repo.upsertYoutubeCapture(normalizeYoutubeCapture({ sessionId: 'preview-fixture-session-001', videoId: 'V3FIXTURE01',
+      title: '羽球 #羽球', url: 'https://www.youtube.com/watch?v=V3FIXTURE01', watchedAt: '2026-09-04T12:00:00Z',
+      actualWatchedSeconds: 30, durationSeconds: 60 }, new Date('2026-09-05T12:00:00Z')));
+    const source = repo.matchingV3Source();
+    store.putCache(classificationKey(s, source.videos[0]), classification);
+    store.putCache(embeddingKey(s, '羽球'), [1, 0]);
+    const original = registry.repositoryFor.bind(registry);
+    registry.repositoryFor = candidate => {
+      assert.equal(registry.userByHandle(candidate.handle)?.id, candidate.id, 'never reopen a stale user database');
+      return original(candidate);
+    };
+    const raceCompute: Compute = { ...compute, cluster: async points => {
+      if (action === 'delete') registry.deleteUser(user.handle);
+      else registry.renameUser(user.handle, 'previewrenamed');
+      return compute.cluster(points);
+    } };
+    assert.deepEqual(await publishCachedPreviews(registry, s, raceCompute), { published: 0, skipped: 1 });
+    assert.equal(store.profile(user.id), null);
+  } finally { registry.close(); }
+});
+
+test('v3 comparison uses independent endpoint while clustering stays on background endpoint', async () => {
+  const original = globalThis.fetch, urls: string[] = [];
+  globalThis.fetch = (async url => { urls.push(String(url)); return new Response('{}'); }) as typeof fetch;
+  try {
+    const client = computeClient({ ...s, computeUrl:'http://background:8090', compareUrl:'http://interactive:8090' });
+    const g=profile().genres.Sport!; const multi={...g,clusters:[{...g.clusters[0],share:0.5},{...g.clusters[0],share:0.5}]};
+    await client.cluster([]); await client.compare(multi,multi);
+    assert.deepEqual(urls,['http://background:8090/cluster','http://interactive:8090/compare']);
+  } finally { globalThis.fetch=original; }
+});
+
+test('v3 singleton transport uses the exact cosine formula without remote solver', async () => {
+  const client = computeClient({...s, computeUrl:'http://unreachable.invalid',similarityFloor:0.7});
+  const g=profile().genres.Sport!;
+  const one=(vector:number[])=>({...g,clusters:[{...g.clusters[0],centroid:vector,share:1}]});
+  assert.equal((await client.compare(one([2,0]),one([4,0]))).score,1);
+  assert.equal((await client.compare(one([1,0]),one([0,1]))).score,0);
+  assert.ok(Math.abs((await client.compare(one([1,0]),one([0.8,0.6]))).score-1/3)<1e-12);
+});
+
+test('v3 cache monitoring can use the compact statistics index', () => {
+  const {db}=storeFixture();
+  try {
+    const plan=db.prepare(`EXPLAIN QUERY PLAN SELECT CASE WHEN json_type(value_json)='array' THEN 'embedding'
+      WHEN json_type(value_json,'$.assignments')='array' THEN 'classification' ELSE 'channel' END kind,
+      count(*) count,max(created_at) latest FROM matching_v3_cache GROUP BY kind`).all();
+    assert.ok(plan.some(row=>String(row.detail).includes('matching_v3_cache_stats')));
+  } finally { db.close(); }
 });


### PR DESCRIPTION
The backup branch retained the repository history from before the author-history rewrite, so GitHub could not compare or merge it with current main. Rebase its remaining work onto the rewritten main while preserving the current product behavior.

Retain the monitoring statistics index, separate comparison endpoint, exact singleton comparison shortcut, cache-only provisional profiles, admin cluster counts, and readable errors for empty/non-JSON responses. Keep the current /matches workspace, private-member discovery and friendship controls, public/friend detail visibility, and production landing assets. The older public-only candidate filter and duplicate landing implementation are superseded by #64/#65/#67. Cached previews also reject stale account identities and concurrent worker publication.

Original tip 1857187 is preserved at `history-backup/20260906/feature/dev-matching-local-backup-20260906` before the branch update. The repaired branch now shares the latest main ancestry without reintroducing the old repository history.

Validation: all 298 Node tests passed with no skips, 6 Python tests passed, desktop/mobile matching browser checks passed, and the development compose configuration validates. Fixtures use isolated temporary/in-memory databases only.
