### PR TITLE
fix: prevent query navigation from resetting anchor scroll

### DIFF
--- a/src/output/query-navigation.ts
+++ b/src/output/query-navigation.ts
@@ -106,6 +106,12 @@ export const queryNavigationScript = String.raw`(()=>{
   addEventListener('popstate', () => {
     const previous = new URL(rendered);
     const next = new URL(location.href);
+    // Native fragment navigation also emits popstate. Let the browser finish
+    // scrolling instead of replacing the page and restoring its old position.
+    if (previous.origin === next.origin && previous.pathname === next.pathname
+      && previous.search === next.search) {
+      cancel(); rendered = location.href; return;
+    }
     previous.searchParams.delete('sort'); next.searchParams.delete('sort');
     if (document.querySelector('[data-youtube-sort]') && previous.href === next.href) {
       cancel();

--- a/tests/query-navigation.test.ts
+++ b/tests/query-navigation.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import vm from 'node:vm';
+import { queryNavigationScript } from '../src/output/query-navigation.js';
+
+test('fragment navigation and history traversal do not fetch or replace the page', () => {
+  const listeners = new Map<string, () => void>();
+  const location = { href: 'https://example.test/?lang=zh', reload() { assert.fail('unexpected reload'); } };
+  let requests = 0;
+  const context = {
+    window: {}, location, URL, AbortController,
+    document: { querySelector: () => null, addEventListener() {} },
+    addEventListener: (type: string, listener: () => void) => listeners.set(type, listener),
+    scrollX: 0, scrollY: 0,
+    fetch: () => { requests++; return new Promise(() => {}); },
+  };
+  vm.runInNewContext(queryNavigationScript, context);
+  for (const hash of ['#community', '#features', '#community', '']) {
+    location.href = `https://example.test/?lang=zh${hash}`;
+    listeners.get('popstate')!();
+    assert.equal(requests, 0, 'native anchor scroll must not trigger a page fetch');
+  }
+  location.href = 'https://example.test/?lang=zh&range=90d';
+  listeners.get('popstate')!();
+  assert.equal(requests, 1, 'query history still refreshes the server-rendered page');
+});


### PR DESCRIPTION
The shared query navigation handler treated native fragment popstate events as query changes. Clicking #community refetched the landing page and restored the scroll position captured during the anchor animation, making the page jump back even with vertical snapping disabled.

Leave same-path, same-query fragment navigation to the browser. Date/range and sort query changes continue through the existing navigation paths.

Validation: reproduced on production; regression test covers multiple fragment jumps, returning to the unfragmented URL, and a subsequent query navigation. npm run check passes (326 passed, 1 skipped).
