### PR TITLE
Add editable profiles, stable handles and social icon buttons

### DIFF
--- a/PROFILE_EDITING.md
+++ b/PROFILE_EDITING.md
@@ -1,0 +1,80 @@
+# Profile editing
+
+Signed-in owners can open `/account/profile` from their account page or their
+profile. This replaces the previous display-name-only form. The editor follows
+the existing English / Traditional Chinese language selection and dark theme.
+It supports an independent display name (1–80 Unicode code points), a handle,
+a plain-text multiline bio (300 code points), and up to five ordered links.
+Link names allow 1–40 code points; URLs allow up to 2048 characters and must be
+absolute HTTP(S) URLs without credentials. Emoji sequences containing multiple
+code points count as multiple characters; both client and server use this rule.
+
+## Migration and deployment
+
+`UserRegistry` automatically adds `bio` (empty), `social_links` (`[]`), and
+`storage_name` to existing registry databases and creates `handle_aliases`.
+Existing filenames are copied from the current handle into `storage_name`;
+no user database files move. Existing `key_seed`, user IDs, Google identities,
+sessions and token hashes stay unchanged. No manual data conversion is needed.
+The backup script now uses `storage_name` and can still read older registries.
+
+Back up the registry and user databases before deployment. Deploy the web,
+ingest, worker and backup processes together and restart them: older binaries
+still derive filenames from handles and must not run once handle editing is
+available. Rolling back to older binaries after a rename requires restoring a
+matching pre-deployment backup or adapting those binaries to `storage_name`.
+
+## Handle changes and privacy
+
+Handles use the existing 2–32 character lowercase letter/digit/dot/dash format,
+starting with a letter or digit. Application routes and service names are
+reserved in `src/profile.ts`. Signup and editing share the same reservation
+rules. Pre-existing reserved handles may be retained when editing other fields;
+reserved application routes always take precedence over historical aliases.
+
+Profile writes require a signed-in session and its form CSRF token. The server
+chooses the user ID from the session, validates the complete form and commits
+all changes and aliases in one SQLite immediate transaction. Account creation
+also takes an immediate transaction so it cannot claim an alias concurrently.
+Only a changed handle requires explicit URL-change acknowledgment.
+
+Old profile URLs, their Insights/History/Recap/Tags subpages and `/u/` JSON URLs
+resolve via the immutable user ID and redirect directly to the latest handle
+with a non-cacheable 302. Valid dashboard keys are exchanged for an ID-based
+HttpOnly cookie before redirection; old handle-based cookies remain accepted.
+Aliases cannot be claimed by another account. Owners can reclaim their own old
+handles; historical aliases remain reserved even if the account is deleted.
+
+Profiles remain behind the existing dashboard public/private access checks.
+Public visitors still receive aggregates only, with no additional history or
+search access. Display names, bios and link names are HTML-escaped; bios render
+with preserved line breaks. Empty bios and link lists produce no empty blocks.
+The editor's link addition/removal/reordering and live counter require JavaScript,
+as do the site's other interactive controls; the server validates every save.
+
+## Validation
+
+`npm run check` covers TypeScript and the complete test suite, including profile
+ownership, CSRF, reserved/invalid/conflicting handles, atomic failed writes,
+Unicode limits, unsafe links, ordered storage, escaping, private access,
+redirects, tokens/sessions, migration/reopen, owner renames and renamed-user
+backup/restore. Browser checks cover adding/reordering/removing links, cancel,
+rename confirmation and save feedback in Chinese, English rendering, and mobile
+and desktop layouts.
+
+## Local interactive preview
+
+Run `npm run dev:profile` and open
+`http://127.0.0.1:4317/account/profile?lang=zh` on the same computer.
+This loopback-only entrypoint signs requests in as an isolated test account;
+it does not use Google login or the production account database. Changes persist
+under the git-ignored `data/profile-preview/` directory, including handle edits.
+Keep the command running while testing. This preview entrypoint must never be
+used for deployment. To test with a real Google account locally, configure a
+separate OAuth client/allowed localhost callback and run the ordinary app instead.
+
+Integration with the current main branch preserves matching and friend access:
+old Overview/Insights URLs honor friendship permissions, while History/Recap
+still require owner/key access. The matching admin allowlist uses the frozen
+`storage_name` identity so a profile rename cannot transfer or remove privileges.
+Existing allowlist entries need no changes; keep their pre-rename identifiers.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
+    "dev:profile": "tsx scripts/preview-profile.ts",
     "start": "tsx src/index.ts",
     "ingest": "tsx src/ingest.ts",
     "worker": "tsx src/youtube-worker.ts",

--- a/scripts/backup.ts
+++ b/scripts/backup.ts
@@ -122,15 +122,18 @@ export function createFullBackup(options: FullBackupOptions): BackupManifest {
     add(options.registryPath, 'users.sqlite');
     const registryBackup = new DatabaseSync(join(partialDir, 'databases', 'users.sqlite'), { readOnly: true });
     let users: string[];
+    let storageNames: string[];
     try {
-      users = (registryBackup.prepare('SELECT handle FROM users ORDER BY id').all() as Array<{ handle: string }>)
-        .map(({ handle }) => handle);
+      const hasStorageName = registryBackup.prepare("SELECT name FROM pragma_table_info('users') WHERE name='storage_name'").get();
+      const rows = registryBackup.prepare(`SELECT handle, ${hasStorageName ? 'COALESCE(storage_name, handle)' : 'handle'} AS storage_name FROM users ORDER BY id`).all() as Array<{ handle: string; storage_name: string }>;
+      users = rows.map(row => row.handle);
+      storageNames = rows.map(row => row.storage_name);
     } finally {
       registryBackup.close();
     }
 
     add(options.databasePath, 'urtube.sqlite');
-    for (const handle of users) {
+    for (const handle of storageNames) {
       if (handle === options.ownerHandle) continue;
       const source = join(options.dataDir, `${handle}.sqlite`);
       // A just-created account may not have opened its data database yet.

--- a/scripts/preview-profile.ts
+++ b/scripts/preview-profile.ts
@@ -1,0 +1,51 @@
+// Isolated, loopback-only profile preview. Never use this entrypoint in production.
+import { mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const previewDir = resolve('data/profile-preview');
+mkdirSync(previewDir, { recursive: true });
+// Set these before importing application modules to prevent the production
+// entrypoint from starting and to keep all preview data in its own directory.
+process.env.NODE_ENV = 'test';
+process.env.PUBLIC_BASE_URL = 'http://127.0.0.1:4317';
+process.env.DATABASE_PATH = resolve(previewDir, 'owner.sqlite');
+process.env.USERS_DATABASE_PATH = resolve(previewDir, 'registry.sqlite');
+process.env.GOOGLE_LOGIN_CLIENT_ID = '';
+process.env.GOOGLE_LOGIN_CLIENT_SECRET = '';
+process.env.YOUTUBE_PRIVATE_DATA_KEY = '';
+process.env.YOUTUBE_CAPTURE_TOKEN = '';
+process.env.INGEST_TOKEN = '';
+
+const { serve } = await import('@hono/node-server');
+const { UserRegistry } = await import('../src/users.js');
+const { createApp } = await import('../src/index.js');
+const registry = new UserRegistry(process.env.USERS_DATABASE_PATH, resolve(previewDir, 'users'));
+let user = registry.listUsers()[0];
+if (!user) {
+  user = registry.createUser('profile-demo', '個人檔案測試');
+  user = registry.updateProfile(user.id, {
+    ...user,
+    bio: '這是本機測試帳號。\n試著編輯名稱、ID、簡介與社群連結。',
+    socialLinks: [{ name: '個人網站', url: 'https://example.com' }],
+  });
+}
+const session = registry.createSession(user);
+const app = createApp(registry);
+const server = serve({
+  hostname: '127.0.0.1', port: 4317,
+  fetch: request => {
+    // Authenticate only this disposable preview account, preserving language
+    // preferences and other ordinary browser cookies. No production DB is used.
+    const headers = new Headers(request.headers);
+    const cookies = (headers.get('cookie') ?? '').split(';').filter(cookie => !cookie.trim().startsWith('urtube_session=')).filter(cookie => cookie.trim());
+    cookies.push(`urtube_session=${session}`);
+    headers.set('cookie', cookies.join('; '));
+    return app.fetch(new Request(request, { headers }));
+  },
+}, () => {
+  console.log('本機測試帳號（與正式帳號分開），資料保存於 data/profile-preview。');
+  console.log('開啟 http://127.0.0.1:4317/account/profile?lang=zh');
+});
+for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+  process.on(signal, () => server.close(() => { registry.close(); process.exit(0); }));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,13 @@
+import { normalizeSocialUrl } from './social-links.js';
+import { createHash } from 'node:crypto';
+import { ProfileError, validHandle, type ProfileInput } from './profile.js';
+import { profileDetails, profileEditPage, profileMessages } from './output/profile.js';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { serve } from '@hono/node-server';
 import { Hono, type Context } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie';
 import { completeGoogleLogin, googleLoginConfigured, googleLoginUrl, suggestedHandle } from './auth.js';
 import { AvatarService, type AvatarImage } from './avatars.js';
@@ -182,6 +187,28 @@ export function createApp(registry: UserRegistry, services: Partial<AppServices>
     return entry.result;
   };
   app.use('*', securityHeaders(true));
+  app.use('/account/profile', bodyLimit({ maxSize: 100_000 }));
+  app.use('*', async (c, next) => {
+    if (c.req.method === 'GET' || c.req.method === 'HEAD') {
+      const url = new URL(c.req.url);
+      const match = url.pathname.match(/^\/(?:u\/)?([^/]+)(\/(?:insights|history|recap|tags|summary\.json|crystal\.json))?$/);
+      const user = match && validHandle(match[1]) ? registry.userByAlias(match[1]) : null;
+      if (user && match) {
+        // Carry a previously issued handle cookie into the stable ID cookie.
+        const oldKey = getCookie(c, `urtube_dash_${match[1]}`);
+        if (oldKey && registry.userByDashboardToken(user.handle, oldKey)) {
+          setCookie(c, `urtube_dash_id_${user.id}`, oldKey, { httpOnly: true, sameSite: 'Lax', path: '/', secure: secureCookies, maxAge: 180 * 86400 });
+        }
+        const keyed = dashboardKeyAccess(c, user);
+        const page = match[2] === '/history' ? 'history' : match[2] === '/recap' ? 'recap' : match[2] === '/insights' ? 'insights' : 'overview';
+        if (!profileAccess(c, user, page) && !keyed && !(oldKey && registry.userByDashboardToken(user.handle, oldKey))) return notFoundPage(c);
+        url.searchParams.delete('key');
+        c.header('Cache-Control', 'no-store');
+        return c.redirect(`${url.pathname.startsWith('/u/') ? '/u' : ''}/${user.handle}${match[2] ?? ''}${url.search}`, 302);
+      }
+    }
+    await next();
+  });
   const v3 = services.matchingV3?.settings ?? matchingV3Settings();
   if (v3.enabled) app.route('/', matchingRoutes(registry, v3, config.publicBaseUrl, services.matchingV3?.compute, (viewer, target, result, lang) => {
     const card = blendCard(viewer, target);
@@ -265,8 +292,8 @@ export function createApp(registry: UserRegistry, services: Partial<AppServices>
   // as its owner, or when the request carries the user's dashboard token
   // (?key=... on first visit, then a cookie).
   function dashboardKeyAccess(c: Context, user: User): boolean {
-    const cookieName = `urtube_dash_${user.handle}`;
-    const key = c.req.query('key') ?? getCookie(c, cookieName) ?? '';
+    const cookieName = `urtube_dash_id_${user.id}`;
+    const key = c.req.query('key') ?? getCookie(c, cookieName) ?? getCookie(c, `urtube_dash_${user.handle}`) ?? '';
     if (!registry.userByDashboardToken(user.handle, key)) return false;
     if (c.req.query('key')) {
       // Path '/' so /compare can also see which dashboards this browser may
@@ -376,6 +403,7 @@ export function createApp(registry: UserRegistry, services: Partial<AppServices>
     return c.html(youtubeDashboardPage(user.displayName, data, requestedSort(c.req.query('sort')), {
       basePath: pagePath,
       profilePath,
+      profileHtml: profileDetails(user, viewerOwns, lang),
       page,
       lang,
       nav: siteNav(c, lang, viewerOwns
@@ -584,7 +612,7 @@ export function createApp(registry: UserRegistry, services: Partial<AppServices>
       if (registry.userByGoogleSub(pending.sub)) {
         return c.html(signupStartPage(t.errGoogleTaken, lang), 409);
       }
-      if (registry.userByHandle(handle)) {
+      if (!registry.handleAvailable(handle)) {
         return c.html(signupCompletePage(pageInput, t.errHandleTaken(handle), lang), 409);
       }
       const created = registry.createUser(handle, displayName, {
@@ -650,8 +678,8 @@ export function createApp(registry: UserRegistry, services: Partial<AppServices>
     const pending = registry.pendingSignup(getCookie(c, 'urtube_signup') ?? '');
     if (!pending) return c.json({ error: 'no pending signup' }, 403);
     const handle = (c.req.query('handle') ?? '').trim().toLocaleLowerCase('en-US');
-    if (!/^[a-z0-9][a-z0-9.-]{1,31}$/.test(handle)) return c.json({ available: false, invalid: true });
-    return c.json({ available: !registry.userByHandle(handle) });
+    if (!validHandle(handle)) return c.json({ available: false, invalid: true });
+    return c.json({ available: registry.handleAvailable(handle) });
   });
 
   app.get('/account', (c) => {
@@ -696,7 +724,7 @@ export function createApp(registry: UserRegistry, services: Partial<AppServices>
         provisional,
         recommendations,
         langToggle(c, lang).href,
-        v3.enabled ? { admin: v3.adminHandles.includes(me.handle), invitations: `<div class="mt-grid">${registry.listUsers()
+        v3.enabled ? { admin: v3.adminHandles.includes(me.storageName), invitations: `<div class="mt-grid">${registry.listUsers()
           .filter(target => target.matchingOptIn && registry.matchingRelationshipFor(me, target.id).status === 'incoming')
           .map(target => candidateCard(blendCard(me, target), me.handle, lang)).join('')}</div>` } : undefined,
       ), v3.enabled && status === 403 ? 200 : status);
@@ -1030,20 +1058,47 @@ export function createApp(registry: UserRegistry, services: Partial<AppServices>
     return c.html(accountPage(me, accountStateFor(me, { rotated }), langOf(c)));
   });
 
-  app.post('/account/profile', async (c) => {
+  function profileCsrf(c: Context): string {
+    return createHash('sha256').update('urtube-profile:' + (getCookie(c, 'urtube_session') ?? '')).digest('hex');
+  }
+
+  app.get('/account/profile', (c) => {
+    c.header('Cache-Control', 'no-store');
     const me = sessionUser(c);
     if (!me) return c.redirect('/signup');
-    const form = await c.req.parseBody();
+    return c.html(profileEditPage(me, profileCsrf(c), langOf(c), me, '', c.req.query('saved') === '1'));
+  });
+
+  app.post('/account/profile', async (c) => {
+    c.header('Cache-Control', 'no-store');
+    const me = sessionUser(c);
+    if (!me) return c.text('Unauthorized', 401);
+    const lang = langOf(c), t = profileMessages(lang);
+    if (c.req.header('sec-fetch-site') === 'cross-site' ||
+        (c.req.header('origin') && c.req.header('origin') !== new URL(config.publicBaseUrl).origin)) {
+      return c.text(t.errors.csrf, 403);
+    }
+    // Bound input before parsing to avoid unbounded form uploads.
+    const raw = await c.req.text();
+    if (Buffer.byteLength(raw) > 100_000) return c.text(t.errors.failed, 413);
+    const form = new URLSearchParams(raw);
+    if (form.get('csrf') !== profileCsrf(c)) return c.text(t.errors.csrf, 403);
+    const names = form.getAll('linkName'), urls = form.getAll('linkUrl'), platforms = form.getAll('linkPlatform');
+    const value: ProfileInput = {
+      displayName: form.get('displayName') ?? '', handle: form.get('handle') ?? '',
+      bio: (form.get('bio') ?? '').replace(/\r\n?/g, '\n'),
+      socialLinks: Array.from({length: Math.max(names.length, urls.length)}, (_, i) => ({name: names[i] ?? '', url: normalizeSocialUrl(platforms[i] ?? '', urls[i] ?? ''), platform: platforms[i] ?? ''})),
+    };
     try {
-      registry.setDisplayName(me.handle, String(form.displayName ?? ''));
-      // The crystal embeds the display name; drop it so /compare and
-      // crystal.json pick up the rename immediately.
+      if (value.handle !== me.handle && form.get('confirmHandleChange') !== '1') {
+        return c.html(profileEditPage(me, profileCsrf(c), lang, value, t.errors.confirm), 400);
+      }
+      const updated = registry.updateProfile(me.id, value);
       clearReadCaches();
-      return c.redirect('/account');
+      return c.redirect('/account/profile?saved=1', 303);
     } catch (error) {
-      return c.html(accountPage(me, accountStateFor(me, {
-        error: error instanceof Error ? error.message : String(error),
-      }), langOf(c)), 400);
+      const detail = error instanceof ProfileError ? t.errors[error.reason === 'taken' ? 'taken' : error.field] : t.errors.failed;
+      return c.html(profileEditPage(me, profileCsrf(c), lang, value, detail), error instanceof ProfileError && error.reason === 'taken' ? 409 : error instanceof ProfileError ? 400 : 500);
     }
   });
 
@@ -1176,7 +1231,7 @@ export function createApp(registry: UserRegistry, services: Partial<AppServices>
     if (String(form.confirmHandle ?? '').trim() !== me.handle) {
       return c.html(accountPage(me, accountStateFor(me, { error: t.errDeleteConfirm }), lang), 400);
     }
-    if (me.handle === DEFAULT_HANDLE) {
+    if (me.storageName === DEFAULT_HANDLE) {
       return c.html(accountPage(me, accountStateFor(me, { error: t.errOwnerDelete }), lang), 400);
     }
     try {
@@ -1294,7 +1349,7 @@ export function createApp(registry: UserRegistry, services: Partial<AppServices>
       user.dashboardPublic
       || me?.id === user.id
       || keyed(user, param)
-      || Boolean(registry.userByDashboardToken(user.handle, getCookie(c, `urtube_dash_${user.handle}`) ?? ''));
+      || Boolean(registry.userByDashboardToken(user.handle, getCookie(c, `urtube_dash_id_${user.id}`) ?? getCookie(c, `urtube_dash_${user.handle}`) ?? ''));
     if (!allowed(a, 'keyA') || !allowed(b, 'keyB')) return notFoundPage(c);
     const comparison = compareCrystals(cachedCrystalFor(registry, a), cachedCrystalFor(registry, b));
     c.header('Cache-Control', 'no-cache');

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -207,7 +207,7 @@ export function createIngestApp(registry: UserRegistry): Hono {
   // worker are configured for the instance owner's account.
   app.post('/api/ingest/youtube/oauth/start', (c) => {
     const context = adminContext(c.req.header('authorization'));
-    if (!context || context.user.handle !== DEFAULT_HANDLE) return c.json({ error: 'Unauthorized' }, 401);
+    if (!context || context.user.storageName !== DEFAULT_HANDLE) return c.json({ error: 'Unauthorized' }, 401);
     try {
       return c.json({ authorizationUrl: youtubeOAuthAuthorizationUrl(context.repository) });
     } catch (error) {

--- a/src/matching-v3/routes.ts
+++ b/src/matching-v3/routes.ts
@@ -37,7 +37,7 @@ export function matchingRoutes(registry: UserRegistry, s: Settings, origin: stri
   for (const path of ['/matching-v3', '/matching-v3/*', '/api/matching-v3', '/api/matching-v3/*']) {
     app.use(path, bodyLimit({ maxSize: 32 * 1024 }), authorize);
   }
-  const isAdmin = (user: User) => s.adminHandles.includes(user.handle);
+  const isAdmin = (user: User) => s.adminHandles.includes(user.storageName);
   const adminOnly: MiddlewareHandler<{ Variables: { user: User } }> = async (c, next) => {
     if (!isAdmin(c.get('user'))) return c.json({ error: 'admin_required' }, 403);
     await next();

--- a/src/output/onboarding.ts
+++ b/src/output/onboarding.ts
@@ -9,7 +9,7 @@ import { html, primaryNav, shell } from './pages.js';
 import { v3ProcessingNotice, v3ProcessingStyles } from './v3-processing.js';
 import type { V3ProcessingStatus } from '../youtube/v3-processing.js';
 
-const formStyles = `
+export const formStyles = `
   .ob-intro{margin:14px 0 26px}
   .ob-profile{align-items:center;display:flex;gap:16px}.ob-profile .ob-avatar{border-radius:50%;flex:0 0 64px;height:64px;object-fit:cover;width:64px}.ob-profile h1{margin-top:3px}
   .ob-intro h1{font-size:clamp(28px,4vw,40px);letter-spacing:-.03em;line-height:1.08;margin:7px 0 10px}
@@ -180,11 +180,7 @@ export function accountPage(user: User, state: AccountPageState = {}, lang: Lang
       <div id="processing">${state.takeoutResult ? '' : processing}</div>
       ${group('settings-profile', t.settingsProfile, `
       <p>${t.accountSignedInAs(html(user.googleEmail ?? ''))}</p>
-      <form method="post" action="/account/profile" class="ob-form" style="margin-top:6px">
-        <label for="displayName">${t.signupName}</label>
-        <input id="displayName" name="displayName" type="text" required maxlength="80" value="${html(user.displayName)}">
-        <button type="submit">${t.accountNameSave}</button>
-      </form>
+      <p><a class="ob-google" href="/account/profile">${lang === 'zh' ? '編輯個人檔案' : 'Edit profile'}</a></p>
       `)}
       ${group('settings-privacy', t.settingsPrivacy, `
       ${matchingSettings}

--- a/src/output/pages.ts
+++ b/src/output/pages.ts
@@ -100,10 +100,18 @@ const styles = `
   details.viz-table table{border-collapse:collapse;margin-top:8px}
   details.viz-table td,details.viz-table th{border-bottom:1px solid var(--line);font-variant-numeric:tabular-nums;padding:4px 14px 4px 0;text-align:left}
 
-  .yt-profile{align-items:center;display:flex;gap:18px;margin:14px 0 22px}
+  .yt-profile{align-items:flex-start;display:flex;gap:18px;margin:14px 0 22px}
   .yt-avatar{background:linear-gradient(140deg,#e66767,#a92f2f);border-radius:50%;display:block;flex:0 0 70px;height:70px;object-fit:cover;width:70px}
+  .yt-profile-copy{min-width:0}.profile-details li{overflow-wrap:anywhere;max-width:100%}
+  .profile-social-buttons{display:flex;flex-wrap:wrap;gap:10px;list-style:none;padding:0;margin:16px 0}
+  .profile-icon-button,.profile-edit-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;min-height:44px;border:1px solid var(--line-strong);background:var(--raised);color:var(--ink);text-decoration:none;transition:background .15s,border-color .15s}
+  .profile-icon-button{width:44px;height:44px;border-radius:50%}.profile-edit-button{border-radius:999px;padding:10px 16px;font-size:13px;font-weight:700}
+  .profile-icon-button:hover,.profile-edit-button:hover{border-color:var(--accent-text);background:var(--surface)}
+  .site-nav a[href="/account/profile"]{border:1px solid var(--line-strong);background:var(--raised);color:var(--ink)}
+  .site-nav a[href="/account/profile"][aria-current=page]{background:var(--ink);color:#111}
+
   .yt-profile-copy h1{font-size:clamp(28px,4vw,40px);letter-spacing:-.03em;line-height:1.05;margin:2px 0 4px}
-  .yt-profile-meta{color:var(--muted);font-size:12px}.yt-profile-meta a{color:var(--ink-2)}
+  .yt-profile-meta{color:var(--muted);font-size:12px}.yt-profile-meta a{color:var(--ink-2);display:inline-flex;align-items:center;min-height:44px;padding:9px 16px;margin-top:8px;border:1px solid var(--line-strong);border-radius:999px;background:var(--raised);text-decoration:none;font-weight:600}
   h1 .h1-scope{color:var(--muted);font-size:.42em;font-style:normal;font-weight:600;letter-spacing:0;margin-left:8px;vertical-align:.22em;white-space:nowrap}
   .yt-range{display:flex;gap:6px;margin-bottom:18px;overflow-x:auto;padding:2px 0}
   .yt-range a{background:var(--surface);border:1px solid var(--line);border-radius:999px;color:var(--ink-2);font-size:12px;font-weight:600;padding:7px 14px;text-decoration:none;white-space:nowrap}

--- a/src/output/profile.ts
+++ b/src/output/profile.ts
@@ -1,0 +1,106 @@
+import { normalizeSocialUrl } from '../social-links.js';
+import { SOCIAL_PRESETS, socialIcon, socialPlatform } from './social-icons.js';
+import type { User } from '../users.js';
+import type { ProfileInput } from '../profile.js';
+import { html, primaryNav, shell } from './pages.js';
+import { formStyles } from './onboarding.js';
+import type { Lang } from './i18n.js';
+
+export function profileMessages(lang: Lang) {
+  return lang === 'zh' ? {
+    title: '編輯個人檔案', name: '顯示名稱', handle: '使用者 ID', bio: '個人簡介', links: '社群連結',
+    help: '選擇平台後，輸入使用者名稱或 @ID 即可。個人網站與自訂連結請填網址，最多 5 筆。',
+    username: '使用者名稱或 @ID', usernameHint: '也可以貼上完整的個人頁面網址。',
+    website: '個人網站', custom: '自訂連結', choose: '新增社群連結',
+    linkName: '連結名稱', url: '網址（http / https）', add: '新增連結', remove: '刪除', up: '上移', down: '下移',
+    save: '儲存變更', cancel: '取消', saved: '個人檔案已儲存。', remaining: '剩餘字數：',
+    hint: '2–32 字元，以小寫英文字母或數字開頭，可含小寫英文字母、數字、點及連字號；不可使用保留字。',
+    warning: '修改 ID 會改變個人頁面網址。舊網址會轉到新網址，舊 ID 會為你保留；登入與紀錄不受影響。',
+    confirm: '我了解個人頁面網址將變更，並同意保留舊網址轉址。', privacy: '沿用帳號目前的公開／私人設定，不會公開額外的觀看或搜尋紀錄。',
+    errors: { displayName: '請填寫 1–80 字的顯示名稱。', handle: 'ID 格式不正確或為保留字。', bio: '個人簡介不可超過 300 字。', socialLinks: '最多 5 筆連結；每筆需有 1–40 字名稱及有效的 http/https 網址（最多 2048 字元，不可含帳密）。', taken: '此 ID 已被使用或保留，請選擇其他 ID。', confirm: '儲存前請勾選網址變更確認。', failed: '儲存失敗，請重試。', csrf: '表單已失效，請重新整理後再試。' },
+  } : {
+    title: 'Edit profile', name: 'Display name', handle: 'User ID', bio: 'Bio', links: 'Social links',
+    help: 'Choose a platform and enter your username or @ID. For websites and custom links, enter a URL. Up to 5 links.',
+    username: 'Username or @ID', usernameHint: 'You can also paste a full profile URL.',
+    website: 'Website', custom: 'Custom link', choose: 'Add social link',
+    linkName: 'Link name', url: 'URL (http / https)', add: 'Add link', remove: 'Remove', up: 'Move up', down: 'Move down',
+    save: 'Save changes', cancel: 'Cancel', saved: 'Profile saved.', remaining: 'Characters remaining: ',
+    hint: '2–32 lowercase letters, digits, dots or dashes; start with a letter or digit. Reserved names are unavailable.',
+    warning: 'Changing your ID changes your profile URL. Old URLs redirect to the new URL and your old ID stays reserved. Login and records stay intact.',
+    confirm: 'I understand my profile URL will change and agree to keep the old URL redirect.', privacy: 'Your current public/private setting still applies. No additional watch or search records will be made public.',
+    errors: { displayName: 'Enter a display name of 1–80 characters.', handle: 'Invalid or reserved ID.', bio: 'Bio must be 300 characters or fewer.', socialLinks: 'Use at most 5 links, each with a 1–40 character name and valid http/https URL (up to 2048 characters, without credentials).', taken: 'This ID is already used or reserved. Choose another ID.', confirm: 'Confirm the URL change before saving.', failed: 'Could not save. Please try again.', csrf: 'This form has expired. Reload and try again.' },
+  };
+}
+
+export function profileDetails(user: User, owns: boolean, lang: Lang): string {
+  return `<div class="profile-details"><p class="muted">@${html(user.handle)}</p>
+    ${user.bio ? `<p style="white-space:pre-wrap;overflow-wrap:anywhere">${html(user.bio)}</p>` : ''}
+    ${user.socialLinks.length ? `<ul class="profile-social-buttons">${user.socialLinks.map(link => `<li><a class="profile-icon-button" href="${html(link.url)}" target="_blank" rel="noopener noreferrer" aria-label="${html(link.name)}" title="${html(link.name)}">${socialIcon(socialPlatform(link.url))}</a></li>`).join('')}</ul>` : ''}
+    ${owns ? `<a class="profile-edit-button" href="/account/profile"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 5 4 4M4 20l4-1L20 7a2.8 2.8 0 0 0-4-4L4 15Z"/></svg>${profileMessages(lang).title}</a>` : ''}</div>`;
+}
+
+export function profileEditPage(user: User, csrf: string, lang: Lang, value: ProfileInput = user, error = '', saved = false): string {
+  const t = profileMessages(lang);
+  const platformName = (id: string) => id === 'website' ? t.website : SOCIAL_PRESETS.find(preset => preset.id === id)!.name;
+  const row = (link: { name: string; url: string; platform?: string }) => {
+    const platform = SOCIAL_PRESETS.some(p => p.id === link.platform) ? link.platform! : socialPlatform(link.url);
+    const usernameMode = platform !== 'website';
+    // Only shorten URLs we can reconstruct exactly. Keep videos, channel IDs,
+    // legacy Threads domains and query strings as full URLs.
+    let input = link.url;
+    try {
+      const path = new URL(link.url).pathname.replace(/^\//, '').replace(/\/$/, '');
+      const candidate = decodeURIComponent(path).replace(/^@/, '');
+      if (normalizeSocialUrl(platform, candidate) === link.url || normalizeSocialUrl(platform, candidate) + '/' === link.url) input = candidate;
+    } catch { /* Preserve invalid input for correction. */ }
+    return `<fieldset class="profile-link" data-input-platform="${html(platform)}"><legend><span data-link-icon>${socialIcon(platform as Parameters<typeof socialIcon>[0])}</span> <span data-link-platform>${platformName(platform)}</span></legend>
+    <input type="hidden" name="linkPlatform" value="${html(platform)}">
+    <label>${t.linkName}<input type="text" name="linkName" required value="${html(link.name)}"></label>
+    <label><span data-input-label>${usernameMode ? t.username : t.url}</span><input type="${usernameMode ? 'text' : 'url'}" name="linkUrl" required maxlength="2048" autocapitalize="none" spellcheck="false" placeholder="${usernameMode ? '@username' : 'https://'}" value="${html(input)}"></label>
+    <small data-input-hint ${usernameMode ? '' : 'hidden'}>${t.usernameHint}</small>
+    <small data-url-preview style="overflow-wrap:anywhere" aria-live="polite">${html(link.url)}</small>
+    <div class="profile-actions"><button type="button" data-action="up">${t.up}</button><button type="button" data-action="down">${t.down}</button><button type="button" data-action="remove">${t.remove}</button></div></fieldset>`;
+  };
+  const body = `<style>${formStyles}
+    .profile-form{max-width:660px}.profile-form textarea,.profile-form input[type=url]{background:var(--raised);border:1px solid var(--line-strong);border-radius:8px;color:var(--ink);font:inherit;padding:11px 12px;width:100%}
+    .profile-form textarea{resize:vertical;min-height:130px}.profile-form small{color:var(--ink-2)}.profile-form label{display:block}.profile-link{min-width:0;border:1px solid var(--line-strong);border-radius:10px;margin:12px 0;padding:14px}.profile-actions{display:flex;flex-wrap:wrap;align-items:center;gap:10px}.profile-actions button{min-height:44px;margin:4px 0}.profile-actions a{padding:11px 18px;border:1px solid var(--line-strong);border-radius:999px;text-decoration:none;background:var(--raised);color:var(--ink);font-weight:700;min-height:44px}.profile-actions a:hover{border-color:var(--accent-text)}.profile-form button:disabled{opacity:.4;cursor:default}.profile-form [hidden]{display:none}.profile-form input[type=checkbox]{min-width:20px;min-height:20px;vertical-align:middle}.profile-form textarea:focus-visible{outline:2px solid var(--accent-text)}
+    .profile-presets{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px}.profile-presets button{display:flex;align-items:center;justify-content:center;gap:8px;min-height:48px;margin:0;padding:10px 6px;background:var(--raised);border:1px solid var(--line-strong);border-radius:10px;color:var(--ink);font-size:13px}.profile-presets button:hover{background:var(--surface);border-color:var(--accent-text)}.profile-link legend{padding:0 6px;font-size:13px;color:var(--ink-2)}
+    @media(max-width:420px){.profile-presets{grid-template-columns:repeat(2,minmax(0,1fr))}}
+    @media(max-width:600px){.profile-form{padding:18px}.profile-actions button{flex:1}.site-nav{flex-wrap:wrap}}
+    </style><section class="ob-intro"><h1>${t.title}</h1><p>${t.privacy}</p></section>
+    <div class="ob-card profile-form">
+    ${error ? `<div class="ob-error" role="alert" tabindex="-1" id="profile-error">${html(error)}</div>` : ''}
+    ${saved ? `<div class="ob-success" role="status">${t.saved}</div>` : ''}
+    <form method="post" action="/account/profile" class="ob-form" id="profile-form">
+    <input type="hidden" name="csrf" value="${html(csrf)}">
+    <label for="displayName">${t.name}</label><input id="displayName" type="text" name="displayName" required value="${html(value.displayName)}">
+    <label for="handle">${t.handle}</label><input id="handle" type="text" name="handle" required minlength="2" maxlength="32" pattern="[a-z0-9][a-z0-9.\\-]{1,31}" autocapitalize="none" spellcheck="false" value="${html(value.handle)}" aria-describedby="handle-hint handle-warning">
+    <small id="handle-hint">${t.hint}</small><div class="ob-warn" id="handle-warning">${t.warning}<p><code>/${html(user.handle)}</code> → <code id="new-url">/${html(value.handle)}</code></p>
+    <label><input type="checkbox" name="confirmHandleChange" value="1" id="confirm-change"> ${t.confirm}</label></div>
+    <label for="bio">${t.bio}</label><textarea id="bio" name="bio" rows="5" aria-describedby="bio-count">
+${html(value.bio)}</textarea><small id="bio-count" aria-live="polite">${t.remaining}<span id="remaining">${300 - [...value.bio].length}</span></small>
+    <h2>${t.links}</h2><p>${t.help}</p>
+    <div class="profile-presets" role="group" aria-label="${t.choose}">
+    ${SOCIAL_PRESETS.map(preset => `<button type="button" data-preset="${preset.id}">${socialIcon(preset.id)}${platformName(preset.id)}</button>`).join('')}
+    <button type="button" id="add-link" data-preset="custom"><span aria-hidden="true">＋</span>${t.custom}</button></div>
+    <div id="profile-links">${value.socialLinks.map(row).join('')}</div>
+    <div class="profile-actions"><button type="submit">${t.save}</button><a href="/${html(user.handle)}">${t.cancel}</a></div>
+    </form><template id="link-template">${row({ name: '', url: '' })}</template></div>
+    <script>(()=>{
+      const form=document.querySelector('#profile-form'), links=document.querySelector('#profile-links'), add=document.querySelector('#add-link'), bio=document.querySelector('#bio'), handle=document.querySelector('#handle'), confirm=document.querySelector('#confirm-change');
+      const presets=${JSON.stringify(SOCIAL_PRESETS)}, icons=${JSON.stringify(Object.fromEntries(SOCIAL_PRESETS.map(preset => [preset.id, socialIcon(preset.id)]))).replace(/</g, '\\u003c')}, websiteName=${JSON.stringify(t.website)};
+      const normalizeUrl=${normalizeSocialUrl.toString()};
+      const usernameLabel=${JSON.stringify(t.username)}, urlLabel=${JSON.stringify(t.url)};
+      const presetButtons=[...document.querySelectorAll('[data-preset]')];
+      const original=${JSON.stringify(user.handle).replace(/</g, '\\u003c')};
+      const refresh=()=>{presetButtons.forEach(button=>button.disabled=links.children.length>=5);[...links.children].forEach((row,i)=>{row.querySelector('[data-action=up]').disabled=i===0;row.querySelector('[data-action=down]').disabled=i===links.children.length-1;});};
+      const updateIcon=row=>{const input=row.querySelector('[name=linkUrl]'), platform=row.querySelector('[name=linkPlatform]').value;const value=normalizeUrl(platform,input.value);let id=platform||'website';if(value){try{const host=new URL(value).hostname.toLowerCase();id=presets.find(p=>p.hosts.some(domain=>host===domain||host.endsWith('.'+domain)))?.id||'website';}catch{}}row.querySelector('[data-link-icon]').innerHTML=icons[id];row.querySelector('[data-link-platform]').textContent=id==='website'?websiteName:presets.find(p=>p.id===id).name;row.querySelector('[data-url-preview]').textContent=/^https?:/.test(value)?value:'';};
+      presetButtons.forEach(button=>button.addEventListener('click',()=>{if(links.children.length>=5)return;links.append(document.querySelector('#link-template').content.cloneNode(true));const row=links.lastElementChild,preset=presets.find(p=>p.id===button.dataset.preset);if(preset){row.querySelector('[name=linkPlatform]').value=preset.id;row.querySelector('[name=linkName]').value=preset.id==='website'?websiteName:preset.name;}const usernameMode=preset&&preset.id!=='website',input=row.querySelector('[name=linkUrl]');input.type=usernameMode?'text':'url';input.placeholder=usernameMode?'@username':(preset?.placeholder||'https://');row.querySelector('[data-input-label]').textContent=usernameMode?usernameLabel:urlLabel;row.querySelector('[data-input-hint]').hidden=!usernameMode;updateIcon(row);refresh();row.querySelector(preset?'[name=linkUrl]':'[name=linkName]').focus();}));
+      links.addEventListener('input',event=>{if(event.target.name==='linkUrl')updateIcon(event.target.closest('fieldset'));});
+      links.addEventListener('click',e=>{const button=e.target.closest('button');if(!button)return;const row=button.closest('fieldset');if(button.dataset.action==='remove'){const next=row.nextElementSibling||row.previousElementSibling;row.remove();(next?.querySelector('input')||add).focus();}else if(button.dataset.action==='up'&&row.previousElementSibling){links.insertBefore(row,row.previousElementSibling);button.focus();}else if(button.dataset.action==='down'&&row.nextElementSibling){links.insertBefore(row.nextElementSibling,row);button.focus();}refresh();});
+      const count=()=>{const remaining=300-[...bio.value.replace(/\\r\\n/g,'\\n')].length;document.querySelector('#remaining').textContent=remaining;bio.setCustomValidity(remaining<0?${JSON.stringify(t.errors.bio)}:'');};
+      const handleChange=()=>{const changed=handle.value!==original;document.querySelector('#handle-warning').hidden=!changed;confirm.required=changed;document.querySelector('#new-url').textContent='/'+handle.value;};
+      handle.addEventListener('input',handleChange);bio.addEventListener('input',count);refresh();count();handleChange();document.querySelector('#profile-error')?.focus();
+    })();</script>`;
+  return shell(t.title, body, primaryNav(lang, { active: 'account', dashboardHref: `/${user.handle}`, languageHref: '/account/profile?lang=' + (lang === 'zh' ? 'en' : 'zh') }), '', lang);
+}

--- a/src/output/social-icons.ts
+++ b/src/output/social-icons.ts
@@ -1,0 +1,25 @@
+// Inline vectors keep profile icons available without external requests.
+export const SOCIAL_PRESETS = [
+  { id: 'instagram', name: 'Instagram', placeholder: 'https://www.instagram.com/username/', hosts: ['instagram.com'] },
+  { id: 'threads', name: 'Threads', placeholder: 'https://www.threads.com/@username', hosts: ['threads.com', 'threads.net'] },
+  { id: 'youtube', name: 'YouTube', placeholder: 'https://www.youtube.com/@channel', hosts: ['youtube.com', 'youtu.be'] },
+  { id: 'github', name: 'GitHub', placeholder: 'https://github.com/username', hosts: ['github.com'] },
+  { id: 'website', name: 'Website', placeholder: 'https://example.com', hosts: [] },
+] as const;
+export type SocialPlatform = typeof SOCIAL_PRESETS[number]['id'];
+export function socialPlatform(value: string): SocialPlatform {
+  try {
+    const host = new URL(value).hostname.toLowerCase();
+    return SOCIAL_PRESETS.find(preset => preset.hosts.some(domain => host === domain || host.endsWith('.' + domain)))?.id ?? 'website';
+  } catch { return 'website'; }
+}
+const artwork: Record<SocialPlatform, string> = {
+  instagram: '<rect x="3" y="3" width="18" height="18" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r=".8" fill="currentColor" stroke="none"/>',
+  threads: '<path d="M20 7C18.8 3.6 16.2 2 12.3 2 6 2 3 6 3 12s3 10 9.3 10c5.1 0 8.7-2.8 8.7-7 0-4.5-4.3-6.3-8.1-6.3-3.2 0-5.1 1.4-5.1 3.7 0 2 1.4 3.4 3.5 3.4 3.1 0 4.3-2.5 4.3-5.8 0-3.2-1.3-4.7-3.6-4.7-1.5 0-2.7.6-3.5 1.7"/>',
+  youtube: '<path d="M21 7.5a2.5 2.5 0 0 0-1.8-1.8C17.5 5.2 12 5.2 12 5.2s-5.5 0-7.2.5A2.5 2.5 0 0 0 3 7.5a22 22 0 0 0 0 9 2.5 2.5 0 0 0 1.8 1.8c1.7.5 7.2.5 7.2.5s5.5 0 7.2-.5a2.5 2.5 0 0 0 1.8-1.8 22 22 0 0 0 0-9Z"/><path d="m10 9 5 3-5 3Z" fill="currentColor" stroke="none"/>',
+  github: '<path fill="currentColor" stroke="none" d="M12 .8a11.2 11.2 0 0 0-3.54 21.83c.56.1.77-.24.77-.54v-2.08c-3.13.68-3.79-1.33-3.79-1.33-.51-1.3-1.25-1.65-1.25-1.65-1.02-.7.08-.69.08-.69 1.13.08 1.72 1.16 1.72 1.16 1 1.72 2.62 1.22 3.26.93.1-.73.39-1.22.71-1.5-2.5-.28-5.12-1.25-5.12-5.55 0-1.22.44-2.22 1.15-3-.12-.29-.5-1.42.11-2.95 0 0 .94-.3 3.08 1.15A10.8 10.8 0 0 1 12 6.2c.95 0 1.9.13 2.8.38 2.14-1.45 3.08-1.15 3.08-1.15.61 1.53.23 2.66.11 2.95.72.78 1.15 1.78 1.15 3 0 4.31-2.63 5.26-5.13 5.54.4.35.76 1.03.76 2.08v3.09c0 .3.2.65.77.54A11.2 11.2 0 0 0 12 .8Z"/>',
+  website: '<circle cx="12" cy="12" r="9"/><ellipse cx="12" cy="12" rx="4" ry="9"/><path d="M3 12h18M5 6.5h14M5 17.5h14"/>',
+};
+export function socialIcon(platform: SocialPlatform): string {
+  return `<svg class="social-icon" data-platform="${platform}" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" style="flex-shrink:0;vertical-align:middle">${artwork[platform]}</svg>`;
+}

--- a/src/output/youtube.ts
+++ b/src/output/youtube.ts
@@ -671,6 +671,7 @@ function recapSection(data: YoutubeDashboardData, t: Messages): string {
 export type YoutubeDashboardPageKind = 'overview' | 'insights' | 'history' | 'recap';
 
 export interface YoutubeDashboardOptions {
+  profileHtml?: string;
   // Path the dashboard is served under; range/sort links stay on it.
   basePath?: string;
   nav?: ShellNavItem[];
@@ -838,6 +839,7 @@ export function youtubeDashboardPage(
     <img class="yt-avatar" src="${html(`/avatar${options.profilePath}`)}" alt="" width="70" height="70">
     <div class="yt-profile-copy"><div class="eyebrow">${t.eyebrowArchive}</div>
     <h1>${html(ownerName)}<em class="h1-scope" data-youtube-sort-scope>${scope}</em></h1>
+    ${options.profileHtml ?? ''}
     <div class="yt-profile-meta"><a href="/">${t.home}</a>${options.blendHref ? ` · <a href="${html(options.blendHref)}">${html(t.memberProfileBlend)}</a>` : ''}</div>${options.friendshipHtml ? `<div class="yt-friendship">${options.friendshipHtml}</div>` : ''}</div></section>`;
   const showRecent = options.showRecent !== false;
   const overview = page === 'overview' ? hero + (options.setupHtml ?? '') + (options.v3Html ?? '')

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const RESERVED_HANDLES = new Set(['landing-assets', 'avatar', 'blend', 'channel', 'dashboard', 'docs', 'matching-v3', 'matches', 'members', 'onboarding', 'account', 'admin', 'api', 'auth', 'compare', 'extension-setup', 'extension-version.json', 'extension.zip', 'favicon.svg', 'healthz', 'login', 'logout', 'og.png', 'privacy', 'readyz', 'robots.txt', 'signup', 'sitemap.xml', 'status', 'support', 'youtube', 'www', 'urtube', 'u']);
+export function validHandle(handle: string): boolean {
+  return /^[a-z0-9][a-z0-9.-]{1,31}$/.test(handle) && !RESERVED_HANDLES.has(handle);
+}
+const textLength = (max: number) => (value: string) => [...value].length <= max;
+export const profileSchema = z.object({
+  displayName: z.string().trim().min(1).refine(textLength(80)),
+  handle: z.string().regex(/^[a-z0-9][a-z0-9.-]{1,31}$/),
+  bio: z.string().refine(textLength(300)).transform(value => value.trim() ? value : ''),
+  socialLinks: z.array(z.object({
+    name: z.string().trim().min(1).refine(textLength(40)),
+    url: z.string().trim().max(2048).refine(value => {
+      try { const url = new URL(value); return /^https?:$/.test(url.protocol) && Boolean(url.hostname) && !url.username && !url.password; }
+      catch { return false; }
+    }),
+  })).max(5),
+});
+export type ProfileInput = z.infer<typeof profileSchema>;
+export class ProfileError extends Error {
+  constructor(public readonly field: keyof ProfileInput, public readonly reason: 'invalid' | 'taken' = 'invalid') { super(`${field}: ${reason}`); }
+}

--- a/src/social-links.ts
+++ b/src/social-links.ts
@@ -1,0 +1,16 @@
+// This pure function is shared with the editor's live URL preview.
+export function normalizeSocialUrl(platform: string, input: string): string {
+  const value = input.trim();
+  if (/^https?:\/\//i.test(value)) return value;
+  const bases: Record<string, string> = {
+    instagram: 'https://www.instagram.com/',
+    threads: 'https://www.threads.com/@',
+    youtube: 'https://www.youtube.com/@',
+    github: 'https://github.com/',
+  };
+  if (!Object.hasOwn(bases, platform)) return value;
+  const username = value.replace(/^@/, '');
+  // Reject paths, query strings, schemes and whitespace; a name is one segment.
+  if (!/^[\p{L}\p{M}\p{N}_.-]+$/u.test(username) || username === '.' || username === '..') return value;
+  return bases[platform] + encodeURIComponent(username);
+}

--- a/src/users.ts
+++ b/src/users.ts
@@ -1,7 +1,8 @@
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
-import { existsSync, mkdirSync, renameSync, rmSync, statSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
+import { profileSchema, ProfileError, validHandle, type ProfileInput } from './profile.js';
 import { config } from './config.js';
 import { MatchingStore } from './matching-v3/store.js';
 import { AdminMonitoring } from './matching-v3/monitoring.js';
@@ -34,13 +35,15 @@ import {
 // The instance owner's handle; override with OWNER_HANDLE (e.g. skyhong.tw).
 export const DEFAULT_HANDLE = process.env.OWNER_HANDLE ?? 'sky';
 
-const HANDLE_PATTERN = /^[a-z0-9][a-z0-9.-]{1,31}$/;
 export type { MatchingDisclosureLevel } from './youtube/disclosure.js';
 
 export interface User {
   id: number;
   handle: string;
   displayName: string;
+  bio: string;
+  socialLinks: ProfileInput['socialLinks'];
+  storageName: string;
   dashboardPublic: boolean;
   referenceOptIn: boolean;
   matchingOptIn: boolean;
@@ -189,6 +192,9 @@ function rowToUser(row: Record<string, unknown>): User {
     id: Number(row.id),
     handle: String(row.handle),
     displayName: String(row.display_name),
+    bio: String(row.bio ?? ''),
+    socialLinks: JSON.parse(String(row.social_links ?? '[]')),
+    storageName: String(row.storage_name ?? row.handle),
     dashboardPublic: Number(row.dashboard_public) === 1,
     referenceOptIn: Number(row.reference_opt_in) === 1,
     matchingOptIn: Number(row.matching_opt_in) === 1,
@@ -261,6 +267,13 @@ export class UserRegistry {
       this.db.exec('ALTER TABLE users ADD COLUMN key_seed TEXT');
     }
     this.db.exec('UPDATE users SET key_seed=handle WHERE key_seed IS NULL');
+    for (const [name, definition] of [['bio', "TEXT NOT NULL DEFAULT ''"], ['social_links', "TEXT NOT NULL DEFAULT '[]'"], ['storage_name', 'TEXT']]) {
+      if (!columns.some(column => column.name === name)) this.db.exec(`ALTER TABLE users ADD COLUMN ${name} ${definition}`);
+    }
+    // Freeze existing filenames; handle edits now only update the registry.
+    this.db.exec('UPDATE users SET storage_name=handle WHERE storage_name IS NULL');
+    this.db.exec(`CREATE TABLE IF NOT EXISTS handle_aliases (handle TEXT PRIMARY KEY, user_id INTEGER NOT NULL)`);
+
     // Google identity: sub is Google's permanent account id (emails can
     // change), unique so one Google account maps to at most one user.
     for (const name of ['google_sub', 'google_email', 'avatar_url']) {
@@ -413,33 +426,40 @@ export class UserRegistry {
       avatarUrl?: string;
     } = {},
   ): CreatedUser {
-    if (!HANDLE_PATTERN.test(handle)) {
+    if (!validHandle(handle)) {
       throw new Error('Handle must be 2-32 chars of lowercase letters, digits, dots, or dashes');
     }
-    const captureToken = newToken();
-    const dashboardToken = newToken();
-    const createdAt = new Date().toISOString();
-    this.db.prepare(`
-      INSERT INTO users (
-        handle, display_name, capture_token_hash, dashboard_token_hash,
-        dashboard_public, data_key_mode, key_seed, created_at, google_sub, google_email, avatar_url,
-        matching_opt_in, matching_disclosure, matching_rhythm
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      handle, displayName, tokenHash(captureToken), tokenHash(dashboardToken),
-      options.dashboardPublic ? 1 : 0, options.dataKeyMode ?? 'derived', handle, createdAt,
-      options.googleSub ?? null, options.googleEmail ?? null, options.avatarUrl ?? null,
-      // Matching switches start on; the account page turns each one off.
-      1, 'topics_and_channel', 1,
-    );
-    const user = this.userByHandle(handle)!;
-    return { ...user, captureToken, dashboardToken };
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      if (!this.handleAvailable(handle)) throw new ProfileError('handle', 'taken');
+      const captureToken = newToken();
+      const dashboardToken = newToken();
+      const createdAt = new Date().toISOString();
+      this.db.prepare(`
+        INSERT INTO users (
+          handle, display_name, capture_token_hash, dashboard_token_hash,
+          dashboard_public, data_key_mode, key_seed, created_at, google_sub, google_email, avatar_url,
+          matching_opt_in, matching_disclosure, matching_rhythm
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        handle, displayName, tokenHash(captureToken), tokenHash(dashboardToken),
+        options.dashboardPublic ? 1 : 0, options.dataKeyMode ?? 'derived', handle, createdAt,
+        options.googleSub ?? null, options.googleEmail ?? null, options.avatarUrl ?? null,
+        // Matching switches start on; the account page turns each one off.
+        1, 'topics_and_channel', 1,
+      );
+      this.db.prepare('UPDATE users SET storage_name=handle WHERE handle=?').run(handle);
+      const user = this.userByHandle(handle)!;
+      this.db.exec('COMMIT');
+      return { ...user, captureToken, dashboardToken };
+    } catch (error) { this.db.exec('ROLLBACK'); throw error; }
   }
 
   // The instance owner: legacy env tokens and the env data key map here, and
   // the migrated Infovore database is this user's data file.
   ensureDefaultUser(): User {
-    const existing = this.userByHandle(DEFAULT_HANDLE);
+    const ownerRow = this.db.prepare('SELECT * FROM users WHERE storage_name=?').get(DEFAULT_HANDLE) as Record<string, unknown> | undefined;
+    const existing = ownerRow ? rowToUser(ownerRow) : this.userByHandle(DEFAULT_HANDLE);
     if (existing) return existing;
     const {
       captureToken: _discardedCaptureToken,
@@ -1114,10 +1134,11 @@ export class UserRegistry {
     if (handle === DEFAULT_HANDLE) throw new Error('Refusing to delete the instance owner');
     const user = this.userByHandle(handle);
     if (!user) throw new Error(`Unknown user: ${handle}`);
-    const repository = this.repositories.get(handle);
+    if (user.storageName === DEFAULT_HANDLE) throw new Error('Refusing to delete the instance owner');
+    const repository = this.repositories.get(String(user.id));
     if (repository) {
       repository.close();
-      this.repositories.delete(handle);
+      this.repositories.delete(String(user.id));
     }
     this.db.prepare('DELETE FROM sessions WHERE user_id=?').run(user.id);
     this.db.prepare('DELETE FROM users WHERE handle=?').run(handle);
@@ -1127,30 +1148,44 @@ export class UserRegistry {
     }
   }
 
+  handleAvailable(handle: string, userId?: number): boolean {
+    const owner = this.userByHandle(handle);
+    const alias = this.db.prepare('SELECT user_id FROM handle_aliases WHERE handle=?').get(handle) as { user_id: number } | undefined;
+    return (!owner || owner.id === userId) && (!alias || alias.user_id === userId);
+  }
+
+  userByAlias(handle: string): User | null {
+    const row = this.db.prepare('SELECT users.* FROM handle_aliases JOIN users ON users.id=handle_aliases.user_id WHERE handle_aliases.handle=?').get(handle) as Record<string, unknown> | undefined;
+    return row ? rowToUser(row) : null;
+  }
+
+  updateProfile(userId: number, input: unknown): User {
+    const parsed = profileSchema.safeParse(input);
+    if (!parsed.success) throw new ProfileError(parsed.error.issues[0].path[0] as keyof ProfileInput);
+    const value = parsed.data;
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      const row = this.db.prepare('SELECT * FROM users WHERE id=?').get(userId) as Record<string, unknown> | undefined;
+      if (!row) throw new Error('Unknown user');
+      const user = rowToUser(row);
+      // Existing accounts may retain a handle that became reserved later.
+      if (value.handle !== user.handle && !validHandle(value.handle)) throw new ProfileError('handle');
+      if (!this.handleAvailable(value.handle, userId)) throw new ProfileError('handle', 'taken');
+      if (user.handle !== value.handle) {
+        this.db.prepare('INSERT OR IGNORE INTO handle_aliases(handle,user_id) VALUES (?,?)').run(user.handle, userId);
+        this.db.prepare('DELETE FROM handle_aliases WHERE handle=? AND user_id=?').run(value.handle, userId);
+      }
+      this.db.prepare('UPDATE users SET handle=?, display_name=?, bio=?, social_links=? WHERE id=?')
+        .run(value.handle, value.displayName, value.bio, JSON.stringify(value.socialLinks), userId);
+      this.db.exec('COMMIT');
+      return this.userByHandle(value.handle)!;
+    } catch (error) { this.db.exec('ROLLBACK'); throw error; }
+  }
+
   renameUser(oldHandle: string, newHandle: string): User {
-    if (!HANDLE_PATTERN.test(newHandle)) {
-      throw new Error('Handle must be 2-32 chars of lowercase letters, digits, dots, or dashes');
-    }
     const user = this.userByHandle(oldHandle);
     if (!user) throw new Error(`Unknown user: ${oldHandle}`);
-    if (this.userByHandle(newHandle)) throw new Error(`Handle already taken: ${newHandle}`);
-    const repository = this.repositories.get(oldHandle);
-    if (repository) {
-      repository.close();
-      this.repositories.delete(oldHandle);
-    }
-    // key_seed intentionally stays put: the encryption key must survive
-    // renames. Only per-user data files move.
-    const oldPath = this.databasePathFor(user);
-    this.db.prepare('UPDATE users SET handle=? WHERE handle=?').run(newHandle, oldHandle);
-    const renamed = this.userByHandle(newHandle)!;
-    const newPath = this.databasePathFor(renamed);
-    if (oldPath !== ':memory:' && newPath !== ':memory:' && oldPath !== newPath && existsSync(oldPath)) {
-      for (const suffix of ['', '-wal', '-shm']) {
-        if (existsSync(`${oldPath}${suffix}`)) renameSync(`${oldPath}${suffix}`, `${newPath}${suffix}`);
-      }
-    }
-    return renamed;
+    return this.updateProfile(user.id, { ...user, handle: newHandle });
   }
 
   userByGoogleSub(sub: string): User | null {
@@ -1308,8 +1343,8 @@ export class UserRegistry {
     if (this.dataDir === ':memory:') return ':memory:';
     // The default user uses the main database path (the migrated Infovore
     // data); everyone else gets their own file under data/users/.
-    if (user.handle === DEFAULT_HANDLE) return config.databasePath;
-    return join(this.dataDir, `${user.handle}.sqlite`);
+    if (user.storageName === DEFAULT_HANDLE) return config.databasePath;
+    return join(this.dataDir, `${user.storageName}.sqlite`);
   }
 
   databaseBytesFor(user: User): number {
@@ -1322,7 +1357,7 @@ export class UserRegistry {
   }
 
   repositoryFor(user: User): Repository {
-    const key = user.handle;
+    const key = String(user.id);
     let repository = this.repositories.get(key);
     if (!repository) {
       repository = new Repository(this.databasePathFor(user));

--- a/src/youtube-worker.ts
+++ b/src/youtube-worker.ts
@@ -78,7 +78,7 @@ export async function runYoutubeWorkerCycle(
     // this archive was last looked at, even when a step fails midway.
     repository.setYoutubeSyncState('worker_cycle_at', now().toISOString());
     try {
-      const portability = user.handle === DEFAULT_HANDLE
+      const portability = user.storageName === DEFAULT_HANDLE
         ? await steps.portability(repository, user)
         : 'not_applicable';
       const metadata = await steps.metadata(repository, user);

--- a/tests/backup.test.ts
+++ b/tests/backup.test.ts
@@ -48,6 +48,7 @@ test('full backup and restore cover registry, owner, and every materialized user
       alice,
       registryMatchingCrystal(buildYoutubeCrystal(aliceRepository, alice)),
     );
+    registry.renameUser('alice', 'alice-renamed');
     new Repository(ownerPath).close();
   } finally {
     registry.close();
@@ -62,7 +63,7 @@ test('full backup and restore cover registry, owner, and every materialized user
       ownerHandle: 'sky',
       privateDataKey: SECRET,
     });
-    assert.deepEqual(manifest.users, ['sky', 'alice']);
+    assert.deepEqual(manifest.users, ['sky', 'alice-renamed']);
     assert.deepEqual(manifest.files.map(({ target }) => target).sort(), [
       'urtube.sqlite', 'users.sqlite', 'users/alice.sqlite',
     ]);

--- a/tests/crystal.test.ts
+++ b/tests/crystal.test.ts
@@ -201,7 +201,9 @@ test('renaming a user keeps tokens and encryption key, moves the dashboard', asy
     assert.equal(registry.dataKeyFor(renamed), keyBefore);
     assert.equal(registry.userByHandle('oldname'), null);
 
-    assert.equal((await app.request('/oldname?key=' + created.dashboardToken)).status, 404);
+    const oldUrl = await app.request('/oldname?key=' + created.dashboardToken);
+    assert.equal(oldUrl.status, 302);
+    assert.equal(oldUrl.headers.get('location'), '/new.name.tw');
     assert.equal((await app.request('/new.name.tw?key=' + created.dashboardToken)).status, 200);
     assert.throws(() => registry.renameUser('missing', 'other'), /Unknown user/);
   } finally {

--- a/tests/matching-v3.test.ts
+++ b/tests/matching-v3.test.ts
@@ -374,6 +374,9 @@ test('v3 admin monitoring requires allowlisted session and reveals no raw profil
       assert.equal((await app.request(path, { headers: viewerHeaders })).status, 403);
       assert.equal((await app.request(path, { headers })).status, 200);
     }
+    registry.renameUser(admin.handle, 'renamed-monitor-admin');
+    assert.equal((await app.request('/api/matching-v3/admin', { headers })).status, 200);
+    assert.throws(() => registry.renameUser(viewer.handle, admin.handle));
     const response = await app.request('/api/matching-v3/admin', { headers });
     assert.equal(response.headers.get('cache-control'), 'no-store');
     const text = await response.text(); assert.ok(!/centroid|apiKey|preferences_json|value_json/.test(text));

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -324,11 +324,13 @@ test('account page toggles dashboard visibility and edits the display name', asy
     assert.ok(accountHtml.includes(`v${bundledVersion}`), 'account shows the bundled extension version');
     assert.deepEqual(await (await app.request('/extension-version.json')).json(), { version: bundledVersion });
 
-    // Display name edits apply immediately.
+    // Display name edits apply immediately with the session-bound form token.
+    const editHtml = await (await app.request('/account/profile', { headers: { cookie: session } })).text();
+    const csrf = editHtml.match(/name="csrf" value="([^"]+)"/)![1];
     await app.request('/account/profile', {
       method: 'POST',
       headers: { cookie: session, 'content-type': 'application/x-www-form-urlencoded' },
-      body: 'displayName=Renamed Vis',
+      body: new URLSearchParams({displayName: 'Renamed Vis', handle: 'vis', bio: '', csrf}).toString(),
     });
     assert.equal(registry.userByHandle('vis')?.displayName, 'Renamed Vis');
 

--- a/tests/profile.test.ts
+++ b/tests/profile.test.ts
@@ -1,0 +1,186 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import test from 'node:test';
+import { createIngestApp } from '../src/ingest.js';
+import { createApp } from '../src/index.js';
+import { UserRegistry } from '../src/users.js';
+import { RESERVED_HANDLES, type ProfileInput } from '../src/profile.js';
+import { profileDetails } from '../src/output/profile.js';
+
+const draft: ProfileInput = { handle: 'alice', displayName: 'Alice', bio: '第一行\nSecond line', socialLinks: [{name: 'GitHub', url: 'https://github.com/alice'}, {name: 'Website', url: 'http://example.com'}] };
+
+async function formFor(app: ReturnType<typeof createApp>, session: string, value = draft) {
+  const page = await app.request('/account/profile', { headers: {cookie: `urtube_session=${session}`} });
+  const csrf = (await page.text()).match(/name="csrf" value="([^"]+)"/)![1];
+  const form = new URLSearchParams({csrf, displayName: value.displayName, handle: value.handle, bio: value.bio});
+  for (const link of value.socialLinks) { form.append('linkName', link.name); form.append('linkUrl', link.url); }
+  return form;
+}
+function post(app: ReturnType<typeof createApp>, session: string, form: URLSearchParams, headers = {}) {
+  return app.request('/account/profile', {method: 'POST', headers: {'content-type': 'application/x-www-form-urlencoded', cookie: `urtube_session=${session}`, ...headers}, body: form.toString()});
+}
+
+test('profile form enforces session ownership, CSRF, explicit rename confirmation and atomic conflicts', async () => {
+  const registry = new UserRegistry(':memory:');
+  try {
+    const alice = registry.createUser('alice', 'Alice'), bob = registry.createUser('bob', 'Bob');
+    const session = registry.createSession(alice), bobSession = registry.createSession(bob);
+    const app = createApp(registry);
+    const form = await formFor(app, session);
+    assert.equal((await post(app, '', form)).status, 401);
+    assert.equal((await post(app, bobSession, form)).status, 403);
+    assert.equal((await post(app, session, form, {origin: 'https://attacker.example'})).status, 403);
+    form.set('userId', String(bob.id));
+    assert.equal((await post(app, session, form)).status, 303);
+    assert.equal(registry.userByHandle('bob')!.bio, '');
+    assert.equal(registry.userByHandle('alice')!.bio, draft.bio);
+    form.set('handle', 'renamed');
+    assert.equal((await post(app, session, form)).status, 400);
+    form.set('confirmHandleChange', '1');
+    form.set('handle', 'bob'); form.set('bio', 'must not save');
+    const conflict = await post(app, session, form);
+    assert.equal(conflict.status, 409);
+    assert.match(await conflict.text(), /must not save/);
+    assert.equal(registry.userByHandle('alice')!.bio, draft.bio);
+    form.set('handle', 'new-alice');
+    assert.equal((await post(app, session, form)).status, 303);
+    assert.equal(registry.userBySession(session)!.handle, 'new-alice');
+    const redirect = await app.request('/alice/history?range=all&key=' + alice.dashboardToken);
+    assert.equal(redirect.status, 302);
+    assert.equal(redirect.headers.get('location'), '/new-alice/history?range=all');
+    assert.match(redirect.headers.get('set-cookie')!, /urtube_dash_id_/);
+    assert.equal((await app.request('/alice')).status, 404);
+    assert.equal((await app.request('/new-alice')).status, 404);
+    assert.equal((await app.request('/new-alice?key=' + alice.dashboardToken)).status, 200);
+    assert.equal((await app.request('/alice', {headers: {cookie: `urtube_dash_alice=${alice.dashboardToken}`}})).status, 302);
+    assert.throws(() => registry.createUser('alice', 'Impostor'), /taken/);
+    assert.equal(registry.userByDashboardToken('new-alice', alice.dashboardToken)!.id, alice.id);
+    assert.equal(registry.userByCaptureToken(alice.captureToken)!.id, alice.id);
+  } finally { registry.close(); }
+});
+
+test('profile validation covers Unicode bounds, reserved IDs, unsafe URLs, array size and persistence of ordering', () => {
+  const registry = new UserRegistry(':memory:');
+  try {
+    const user = registry.createUser('alice', 'Alice');
+    for (const handle of [...RESERVED_HANDLES, '../escape', 'AlicE', 'a', 'a'.repeat(33)]) {
+      assert.throws(() => registry.updateProfile(user.id, {...draft, handle}));
+      assert.throws(() => registry.createUser(handle, 'Bad'));
+    }
+    for (const url of ['javascript:alert(1)', 'data:text/html,test', '//example.com', 'ftp://example.com', 'https://user:pass@example.com', 'not a url']) {
+      assert.throws(() => registry.updateProfile(user.id, {...draft, socialLinks: [{name: 'Bad', url}]}));
+    }
+    for (const invalid of [{bio: '😀'.repeat(301)}, {displayName: ' '}, {displayName: '😀'.repeat(81)}, {socialLinks: Array(6).fill(draft.socialLinks[0])}, {socialLinks: [{name: '', url: 'https://example.com'}]}]) {
+      assert.throws(() => registry.updateProfile(user.id, {...draft, ...invalid}));
+    }
+    const updated = registry.updateProfile(user.id, {...draft, bio: '😀'.repeat(300), socialLinks: [...draft.socialLinks].reverse()});
+    assert.equal([...updated.bio].length, 300);
+    assert.equal(updated.socialLinks[0].name, 'Website');
+    assert.equal(updated.dashboardPublic, false);
+    const cleared = registry.updateProfile(user.id, {...draft, bio: '', socialLinks: []});
+    assert.equal(cleared.bio, ''); assert.deepEqual(cleared.socialLinks, []);
+    assert.doesNotMatch(profileDetails(cleared, false, 'en'), /<ul|white-space/);
+  } finally { registry.close(); }
+});
+
+test('stored profile text is escaped; public profile does not grant editing or reveal private history', async () => {
+  const registry = new UserRegistry(':memory:');
+  try {
+    const user = registry.createUser('alice', 'Alice', {dashboardPublic: true});
+    const updated = registry.updateProfile(user.id, {...draft, bio: '<script>alert(1)</script>\nHello', displayName: '<b>Alice</b>'});
+    const markup = profileDetails(updated, false, 'zh');
+    assert.match(markup, /&lt;script&gt;/); assert.doesNotMatch(markup, /<script>|account\/profile/);
+    assert.match(markup, /noopener noreferrer/);
+    const app = createApp(registry);
+    const publicPage = await (await app.request('/alice')).text();
+    assert.match(publicPage, /@alice/); assert.match(publicPage, /&lt;b&gt;Alice/);
+    assert.doesNotMatch(publicPage, /<a\b[^>]*href="\/account\/profile"/);
+    assert.equal((await app.request('/account/profile')).status, 302);
+    const session = registry.createSession(user);
+    const editor = await (await app.request('/account/profile?lang=zh', {headers: {cookie: `urtube_session=${session}`}})).text();
+    assert.match(editor, /編輯個人檔案/); assert.match(editor, /剩餘字數/);
+    assert.match(editor, /&lt;script&gt;/);
+  } finally { registry.close(); }
+});
+
+test('existing registry migrates idempotently; repeated renames keep data, encryption, owner and sessions across reopen', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'urtube-profile-'));
+  const path = join(dir, 'registry.sqlite');
+  let registry = new UserRegistry(path);
+  const user = registry.createUser('alice', 'Alice', {googleSub: 'permanent-google-id'});
+  const session = registry.createSession(user), key = registry.dataKeyFor(user), dataPath = registry.databasePathFor(user);
+  registry.repositoryFor(user).setYoutubeSyncState('fixture', 'preserved');
+  registry.close();
+  // Reproduce a registry from before this feature; user data remains on disk.
+  const old = new DatabaseSync(path);
+  old.exec('ALTER TABLE users DROP COLUMN bio; ALTER TABLE users DROP COLUMN social_links; ALTER TABLE users DROP COLUMN storage_name; DROP TABLE handle_aliases;');
+  old.close();
+  registry = new UserRegistry(path);
+  try {
+    const migrated = registry.userByHandle('alice')!;
+    assert.equal(migrated.bio, ''); assert.deepEqual(migrated.socialLinks, []);
+    const repo = registry.repositoryFor(migrated);
+    registry.updateProfile(user.id, {...draft, handle: 'alice-two'});
+    const renamed = registry.renameUser('alice-two', 'alice-three');
+    assert.equal(registry.repositoryFor(renamed), repo);
+    assert.equal(registry.databasePathFor(renamed), dataPath);
+    assert.equal(registry.dataKeyFor(renamed), key);
+    assert.equal(registry.userByAlias('alice')!.id, user.id);
+    assert.equal(registry.userByAlias('alice-two')!.id, user.id);
+    registry.close(); registry = new UserRegistry(path);
+    const persisted = registry.userBySession(session)!;
+    assert.equal(persisted.handle, 'alice-three'); assert.equal(persisted.bio, draft.bio);
+    assert.deepEqual(persisted.socialLinks, draft.socialLinks);
+    assert.equal(registry.userByGoogleSub('permanent-google-id')!.id, user.id);
+    assert.equal(registry.repositoryFor(persisted).youtubeSyncState('fixture'), 'preserved');
+    registry.renameUser('alice-three', 'alice');
+    assert.equal(registry.userByAlias('alice'), null);
+    assert.equal(registry.userByAlias('alice-three')!.handle, 'alice');
+    const owner = registry.ensureDefaultUser(), ownerPath = registry.databasePathFor(owner);
+    const renamedOwner = registry.renameUser(owner.handle, 'owner-new');
+    assert.equal(registry.ensureDefaultUser().id, owner.id);
+    assert.equal(registry.databasePathFor(renamedOwner), ownerPath);
+    assert.throws(() => registry.deleteUser(renamedOwner.handle), /instance owner/);
+  } finally { registry.close(); rmSync(dir, {recursive: true, force: true}); }
+});
+
+
+test('owner import authorization survives a handle edit', async () => {
+  const registry = new UserRegistry(':memory:');
+  try {
+    const owner = registry.ensureDefaultUser();
+    registry.renameUser(owner.handle, 'renamed-owner');
+    const captureToken = registry.rotateCaptureToken('renamed-owner');
+    const ingest = createIngestApp(registry);
+    const response = await ingest.request('/api/ingest/youtube/oauth/start', {method: 'POST', headers: {authorization: `Bearer ${captureToken}`}});
+    // OAuth may be unconfigured in tests, but the owner passes authorization.
+    assert.notEqual(response.status, 401);
+  } finally { registry.close(); }
+});
+
+test('platform usernames become URLs on the server without client JavaScript', async () => {
+  const registry = new UserRegistry(':memory:');
+  try {
+    const user = registry.createUser('alice', 'Alice'), session = registry.createSession(user);
+    const app = createApp(registry);
+    const platforms = ['instagram', 'threads', 'youtube', 'github'];
+    const form = await formFor(app, session, {...draft, socialLinks: platforms.map(name => ({name, url: '@alice'}))});
+    platforms.forEach(platform => form.append('linkPlatform', platform));
+    assert.equal((await post(app, session, form)).status, 303);
+    assert.deepEqual(registry.userByHandle('alice')!.socialLinks.map(link => link.url), [
+      'https://www.instagram.com/alice', 'https://www.threads.com/@alice',
+      'https://www.youtube.com/@alice', 'https://github.com/alice',
+    ]);
+    const invalid = await formFor(app, session, {...draft, socialLinks: [{name:'GitHub', url:'javascript:alert(1)'}]});
+    invalid.append('linkPlatform', 'github');
+    assert.equal((await post(app, session, invalid)).status, 400);
+    invalid.set('linkUrl', 'alice/../../other');
+    assert.equal((await post(app, session, invalid)).status, 400);
+    invalid.set('linkUrl', 'https://github.com/alice?tab=repositories');
+    assert.equal((await post(app, session, invalid)).status, 303);
+    assert.equal(registry.userByHandle('alice')!.socialLinks[0].url, 'https://github.com/alice?tab=repositories');
+  } finally { registry.close(); }
+});

--- a/tests/youtube-worker.test.ts
+++ b/tests/youtube-worker.test.ts
@@ -11,7 +11,7 @@ import { classifyYoutubeVideosForMatching } from '../src/youtube/matching.js';
 test('YouTube worker enriches every user while keeping portability owner-only', async () => {
   const registry = new UserRegistry(':memory:');
   try {
-    const owner = registry.ensureDefaultUser();
+    const owner = registry.renameUser(registry.ensureDefaultUser().handle, 'renamed-owner');
     const alice = registry.createUser('alice', 'Alice');
     const bob = registry.createUser('bob', 'Bob');
     const calls: string[] = [];


### PR DESCRIPTION
Adds a profile editor from account settings and the owner's profile, with an independent display name, editable handle, 300-character multiline bio, and up to five ordered social links. Platform presets accept usernames or full URLs; public profiles render accessible icon buttons. English and Traditional Chinese follow the existing language setting.

Handle changes require explicit confirmation and preserve old URLs through reserved aliases. Stable storage names keep databases, keys, sessions, Google identities, matching relationships and admin privileges attached to the same account. Profile writes enforce session ownership, CSRF, server validation and atomic uniqueness checks. Existing avatar, navigation, matching and privacy behavior is preserved.

Validation: `npm run check` on current main — 332 passed, 1 pre-existing skip, no failures. Coverage includes profile permissions, ID conflicts, Unicode limits, unsafe URLs, username conversion, persistence, migration, renames and backup/restore; admin rename permissions are also covered. The local preview was checked in desktop/mobile layouts.

Deployment: additive registry migration runs automatically. Update/restart web, ingest, worker and backup binaries together; older binaries derive data paths from handles. Do not change matching admin allowlist entries when a user renames. No deployment or backfill is included. See PROFILE_EDITING.md.
