### PR TITLE
fix: align channel viewer counts across cards

### DIFF
--- a/src/output/channel.ts
+++ b/src/output/channel.ts
@@ -85,6 +85,7 @@ export interface ChannelPageData {
 }
 
 const styles = `
+  .ch-channel .ch-main strong{min-height:2.8em}
   .site-main{padding-top:14px}
   .ch-page .section{background:none;border:0;border-radius:0;box-shadow:none;margin-top:24px;padding:0}
   .ch-page .section-head{align-items:baseline;gap:6px 14px;justify-content:flex-start;margin-bottom:10px;min-height:28px;padding-right:120px}.ch-page .section-head h2{font-size:19px;letter-spacing:-.025em}.ch-page .section-head span{font-size:12px}

--- a/src/output/landing-channels.ts
+++ b/src/output/landing-channels.ts
@@ -24,6 +24,7 @@ export function landingChannelShelf(channels: CommunityChannel[], mode: 'duratio
 }
 
 export const landingShelfStyles = `
+  .ch-channel .ch-main strong{min-height:2.8em}
   .site-main{padding-top:14px}
   .ch-page .section{background:none;border:0;border-radius:0;box-shadow:none;margin-top:24px;padding:0}
   .ch-page .section-head{align-items:baseline;gap:6px 14px;justify-content:flex-start;margin-bottom:10px;min-height:28px;padding-right:120px}.ch-page .section-head h2{font-size:19px;letter-spacing:-.025em}.ch-page .section-head span{font-size:12px}


### PR DESCRIPTION
## Summary
Reserve two lines for channel names so member viewer counts align across cards with single-line and wrapped names. Apply the same CSS to the channel directory and landing page shelves.

## Validation
- TypeScript check passed.
- Browser alignment checks passed at 1280px and 390px in horizontal and expanded grid layouts using synthetic content.
- Two CSS declarations only; no backend changes.
