### PR TITLE
Prepare CI-gated production deployment timer

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Test deployment gate
+        run: python3 scripts/cd/test_cd.py
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/docs/plans/2026-09-06-continuous-deployment.md
+++ b/docs/plans/2026-09-06-continuous-deployment.md
@@ -1,0 +1,12 @@
+# Continuous deployment implementation plan
+
+Goal: automatically deploy the current main commit only after its push Check workflow succeeds.
+
+Architecture: a user systemd timer on skyhong-SM polls GitHub every five minutes using Python's standard library. It invokes the existing allowlisted `deploy.sh <sha>` and preserves host-owned Compose configuration and credentials. A separate deployment checkout must be confirmed from the host script before activation.
+
+1. Implement the exact-SHA CI gate and synthetic checks for pending, failed, stale and PR runs.
+2. Add a serialized deployment command, persistent success/failure state and bounded public health checks. Failed deployments require operator intervention; do not retry production mutations every timer tick.
+3. Install a user service/timer and validate syntax and read-only CI inspection on the host.
+4. Inspect host deploy/up scripts, verify source checkout and production revision, then enable and verify a real deployment. Keep the timer disabled if this prerequisite is unavailable.
+
+No application behavior, user data, AI quotas, or classification caches are changed by these files. Deployment recreates services according to the existing host script, which must be inspected first.

--- a/scripts/cd/README.md
+++ b/scripts/cd/README.md
@@ -1,0 +1,57 @@
+# urtube CD
+
+A user systemd timer checks the current `main` commit against the latest `Check`
+push run every five minutes. Only a completed successful run for that exact SHA
+can invoke `sudo -n -u deck /home/deck/urtube-ops/deploy.sh <sha>`.
+No GitHub token, inbound webhook, self-hosted Actions runner, or new dependency
+is needed for this public repository.
+
+## Installation prerequisites
+
+Read the host-owned deploy/up scripts first. Verify that `deploy.sh <sha>` fetches
+and deploys the supplied immutable commit and retains all production overlays,
+volume names, secrets and service settings. Verify the current running revision;
+do not initialize state from main without proving that revision is deployed.
+The current source checkout and production overlays differ from the historical
+CUTOVER_RUNBOOK examples. Never substitute those old commands.
+
+Copy the Python file to `~/.local/lib/urtube-cd/` and the two unit files to
+`~/.config/systemd/user/`. Run `loginctl enable-linger urtube` so it survives logout.
+
+Validate without deploying:
+
+```sh
+python3 scripts/cd/test_cd.py
+python3 ~/.local/lib/urtube-cd/urtube-cd.py
+systemd-analyze --user verify ~/.config/systemd/user/urtube-cd.service ~/.config/systemd/user/urtube-cd.timer
+```
+
+Only after the prerequisites are verified, create
+`~/.local/state/urtube-cd/state.json` containing
+`{"deployed":"<verified currently deployed 40-character SHA>"}` and enable:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now urtube-cd.timer
+systemctl --user start urtube-cd.service
+journalctl --user -u urtube-cd.service -n 50 --no-pager
+```
+
+## Failure and recovery
+
+The script records `attempted` before dispatch. Any deployment error, timeout,
+interruption, or failed public health check leaves it set and blocks further
+production changes until an operator investigates. Missing or malformed state
+also prevents deployment. It never automatically restores databases, retries a
+failed deployment, or assumes an image rollback is safe after a schema change.
+
+After repairing or reverting through the host deployment procedure, verify the
+running source revision and health, then replace state with that verified
+`deployed` SHA (without `attempted`). Logs are in the user journal; no external
+notification is configured. Pause with `systemctl --user stop urtube-cd.timer`.
+Stopping the timer does not interrupt an already running deployment.
+
+Public health confirms availability, not source identity. Deployment source
+identity must be guaranteed by the reviewed host script and its evidence.
+Changes to the CD agent itself require explicit installation; a new main commit
+does not silently replace the deployment control program.

--- a/scripts/cd/README.md
+++ b/scripts/cd/README.md
@@ -55,3 +55,18 @@ Public health confirms availability, not source identity. Deployment source
 identity must be guaranteed by the reviewed host script and its evidence.
 Changes to the CD agent itself require explicit installation; a new main commit
 does not silently replace the deployment control program.
+
+## Cache cleanup
+
+After a successful deployment and public health checks, remove unused dangling
+images older than seven days (`docker image prune --filter until=168h`) and
+build cache unused for seven days, retaining a 2 GB build-cache reserve
+(`docker builder prune --filter until=168h --reserved-space 2GB`). The host's
+Docker CLI supports this Buildx option. Tagged images, running containers and
+volumes are not pruned. Cache pruning is daemon-wide and can make later builds
+of other projects slower. A cleanup error is reported as a service failure but
+does not cause the already successful release to be redeployed.
+
+On this host Docker uses `/home/.docker-data` (a separate loop filesystem).
+Reclaiming space inside it does not necessarily free the backing `/home`
+filesystem, so monitor both separately.

--- a/scripts/cd/test_cd.py
+++ b/scripts/cd/test_cd.py
@@ -33,6 +33,8 @@ with tempfile.TemporaryDirectory() as directory:
     with patch("sys.argv", ["urtube-cd.py", "--deploy"]), patch.object(cd, "candidate", return_value=sha), patch.object(cd, "get_json", return_value={"object": {"sha": sha}}), patch.object(cd, "healthy"), patch.object(cd.subprocess, "run") as deploy:
         cd.main()
         cd.main()
-        assert deploy.call_count == 1
+        assert deploy.call_count == 3
+        assert deploy.call_args_list[1].args[0][1:] == ["image", "prune", "--force", "--filter", "until=168h"]
+        assert deploy.call_args_list[2].args[0][1:] == ["builder", "prune", "--force", "--filter", "until=168h", "--reserved-space", "2GB"]
         assert cd.json.loads((cd.STATE / "state.json").read_text()) == {"deployed": sha}
 print("CD success and failure-state checks passed")

--- a/scripts/cd/test_cd.py
+++ b/scripts/cd/test_cd.py
@@ -1,0 +1,38 @@
+"""Synthetic CI gate checks. Never connects to a database or production host."""
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("cd", Path(__file__).with_name("urtube-cd.py"))
+cd = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cd)
+sha = "a" * 40
+run = dict(head_sha=sha, head_branch="main", event="push", path=".github/workflows/check.yml", status="completed", conclusion="success")
+assert cd.passed(sha, run)
+for field, value in (("head_sha", "b" * 40), ("head_branch", "feature"), ("event", "pull_request"), ("path", ".github/workflows/other.yml"), ("status", "in_progress"), ("conclusion", "failure"), ("conclusion", "cancelled"), ("conclusion", None)):
+    assert not cd.passed(sha, {**run, field: value}), (field, value)
+assert not cd.passed("main", {**run, "head_sha": "main"})
+assert not cd.passed(sha, {})
+print("CD gate checks passed")
+
+# Exercise persistent failure handling without invoking SSH, sudo, or the network.
+import tempfile
+from unittest.mock import patch
+with tempfile.TemporaryDirectory() as directory:
+    cd.STATE = Path(directory)
+    cd.save({"deployed": "b" * 40})
+    with patch("sys.argv", ["urtube-cd.py", "--deploy"]), patch.object(cd, "candidate", return_value=sha), patch.object(cd, "get_json", return_value={"object": {"sha": sha}}), patch.object(cd, "healthy"), patch.object(cd.subprocess, "run", side_effect=RuntimeError("synthetic deployment failure")) as deploy:
+        for _ in range(2):
+            try:
+                cd.main()
+                raise AssertionError("failed deployment must block")
+            except RuntimeError:
+                pass
+        assert deploy.call_count == 1
+        assert cd.json.loads((cd.STATE / "state.json").read_text())["attempted"] == sha
+    cd.save({"deployed": "b" * 40})
+    with patch("sys.argv", ["urtube-cd.py", "--deploy"]), patch.object(cd, "candidate", return_value=sha), patch.object(cd, "get_json", return_value={"object": {"sha": sha}}), patch.object(cd, "healthy"), patch.object(cd.subprocess, "run") as deploy:
+        cd.main()
+        cd.main()
+        assert deploy.call_count == 1
+        assert cd.json.loads((cd.STATE / "state.json").read_text()) == {"deployed": sha}
+print("CD success and failure-state checks passed")

--- a/scripts/cd/urtube-cd.py
+++ b/scripts/cd/urtube-cd.py
@@ -92,6 +92,9 @@ def main():
         healthy()
         save({"deployed": sha})
         print("Deployment command and public health checks succeeded:", sha, flush=True)
+        docker = str(Path.home() / ".local/bin/docker")
+        subprocess.run([docker, "image", "prune", "--force", "--filter", "until=168h"], check=True, timeout=300)
+        subprocess.run([docker, "builder", "prune", "--force", "--filter", "until=168h", "--reserved-space", "2GB"], check=True, timeout=300)
 
 
 if __name__ == "__main__":

--- a/scripts/cd/urtube-cd.py
+++ b/scripts/cd/urtube-cd.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Poll the public repository and deploy only a successful main push commit."""
+import argparse
+import fcntl
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import time
+from urllib.request import Request, urlopen
+
+API = "https://api.github.com/repos/skyhong2002/urtube.observe.tw"
+STATE = Path.home() / ".local/state/urtube-cd"
+
+
+def get_json(url):
+    request = Request(url, headers={"Accept": "application/json", "User-Agent": "urtube-cd"})
+    with urlopen(request, timeout=20) as response:
+        return json.load(response)
+
+
+def passed(sha, run):
+    return bool(re.fullmatch(r"[0-9a-f]{40}", sha)) and all((
+        run.get("head_sha") == sha,
+        run.get("head_branch") == "main",
+        run.get("event") == "push",
+        run.get("path") == ".github/workflows/check.yml",
+        run.get("status") == "completed",
+        run.get("conclusion") == "success",
+    ))
+
+
+def candidate():
+    sha = get_json(API + "/git/ref/heads/main")["object"]["sha"]
+    runs = get_json(API + "/actions/workflows/check.yml/runs?branch=main&event=push&per_page=1")["workflow_runs"]
+    return sha if runs and passed(sha, runs[0]) else None
+
+
+def save(state):
+    temporary = STATE / "state.tmp"
+    temporary.write_text(json.dumps(state) + "\n")
+    os.replace(temporary, STATE / "state.json")
+
+
+def healthy():
+    for attempt in range(12):
+        try:
+            for endpoint in ("healthz", "readyz"):
+                with urlopen("https://urtube.observe.tw/" + endpoint, timeout=10) as response:
+                    if response.status != 200:
+                        raise RuntimeError("Unhealthy " + endpoint)
+            return
+        except Exception:
+            if attempt == 11:
+                raise
+            time.sleep(10)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--deploy", action="store_true", help="invoke the host deployment script; default is read-only")
+    args = parser.parse_args()
+    if not args.deploy:
+        print("CI-approved main:", candidate() or "none")
+        return
+    STATE.mkdir(parents=True, exist_ok=True)
+    with (STATE / "lock").open("w") as lock:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return
+        sha = candidate()
+        if not sha:
+            print("Current main has no completed successful Check push run; skipping.")
+            return
+        print("CI-approved main:", sha, flush=True)
+        state = json.loads((STATE / "state.json").read_text())
+        if not re.fullmatch(r"[0-9a-f]{40}", state.get("deployed", "")):
+            raise RuntimeError("Initialize state with the verified running commit first")
+        if state.get("attempted"):
+            raise RuntimeError("Previous deployment needs operator inspection: " + state["attempted"])
+        if state.get("deployed") == sha:
+            return
+        # Check main again immediately before dispatching the immutable SHA.
+        if get_json(API + "/git/ref/heads/main")["object"]["sha"] != sha:
+            print("Main advanced; waiting for the next tick.")
+            return
+        state["attempted"] = sha
+        save(state)
+        subprocess.run(["sudo", "-n", "-u", "deck", "/home/deck/urtube-ops/deploy.sh", sha], check=True, timeout=1800)
+        healthy()
+        save({"deployed": sha})
+        print("Deployment command and public health checks succeeded:", sha, flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cd/urtube-cd.service
+++ b/scripts/cd/urtube-cd.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Deploy CI-approved urtube main
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/python3 %h/.local/lib/urtube-cd/urtube-cd.py --deploy
+Environment=PATH=/home/urtube/.local/bin:/usr/local/bin:/usr/bin
+TimeoutStartSec=40min
+UMask=0077

--- a/scripts/cd/urtube-cd.timer
+++ b/scripts/cd/urtube-cd.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Check urtube main for deployment every five minutes
+
+[Timer]
+OnStartupSec=2min
+OnUnitInactiveSec=5min
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Prepare a host-side systemd timer that deploys the current main SHA only after its Check push workflow succeeds. It reuses the existing allowlisted deploy script, serializes attempts, checks public health, and blocks further deployments after failures pending operator inspection.

After successful deployment, prune dangling images older than seven days and build cache unused for seven days, with a 2 GB build-cache reserve. Tagged images and data volumes are retained.

Validation: synthetic CI eligibility, deployment-state and cleanup-command checks pass locally and on skyhong-SM. Installed systemd units validate; read-only polling identifies the successful main commit. The new gate check is included in CI.

Activation remains blocked pending read access to host-owned deploy/up scripts and verification of the running source SHA and production overlays. The earlier full /home filesystem has recovered to 53 GB free. Files are now installed and user linger is enabled, but the timer is disabled and no production deployment or cache cleanup has been executed.
