### PR TITLE
Compact profile actions and remove redundant Home button

### DIFF
--- a/src/output/pages.ts
+++ b/src/output/pages.ts
@@ -104,9 +104,10 @@ const styles = `
   .yt-profile{align-items:flex-start;display:flex;gap:18px;margin:14px 0 22px}
   .yt-avatar{background:linear-gradient(140deg,#e66767,#a92f2f);border-radius:50%;display:block;flex:0 0 70px;height:70px;object-fit:cover;width:70px}
   .yt-profile-copy{min-width:0}.profile-details li{overflow-wrap:anywhere;max-width:100%}
-  .profile-social-buttons{display:flex;flex-wrap:wrap;gap:10px;list-style:none;padding:0;margin:16px 0}
+  .profile-action-row{display:flex;align-items:center;flex-wrap:wrap;gap:10px;margin:16px 0}
+  .profile-social-buttons{display:flex;flex-wrap:wrap;gap:10px;list-style:none;padding:0;margin:0}
   .profile-icon-button,.profile-edit-button{display:inline-flex;align-items:center;justify-content:center;gap:8px;min-height:44px;border:1px solid var(--line-strong);background:var(--raised);color:var(--ink);text-decoration:none;transition:background .15s,border-color .15s}
-  .profile-icon-button{width:44px;height:44px;border-radius:50%}.profile-edit-button{border-radius:999px;padding:10px 16px;font-size:13px;font-weight:700}
+  .profile-icon-button{width:44px;height:44px;border-radius:50%}.profile-edit-button{width:44px;height:44px;border-radius:50%;padding:0}
   .profile-icon-button:hover,.profile-edit-button:hover{border-color:var(--accent-text);background:var(--surface)}
   .site-nav a[href="/account/profile"]{border:1px solid var(--line-strong);background:var(--raised);color:var(--ink)}
   .site-nav a[href="/account/profile"][aria-current=page]{background:var(--ink);color:#111}

--- a/src/output/profile.ts
+++ b/src/output/profile.ts
@@ -35,8 +35,10 @@ export function profileMessages(lang: Lang) {
 export function profileDetails(user: User, owns: boolean, lang: Lang): string {
   return `<div class="profile-details"><p class="muted">@${html(user.handle)}</p>
     ${user.bio ? `<p style="white-space:pre-wrap;overflow-wrap:anywhere">${html(user.bio)}</p>` : ''}
+    ${user.socialLinks.length || owns ? '<div class="profile-action-row">' : ''}
     ${user.socialLinks.length ? `<ul class="profile-social-buttons">${user.socialLinks.map(link => `<li><a class="profile-icon-button" href="${html(link.url)}" target="_blank" rel="noopener noreferrer" aria-label="${html(link.name)}" title="${html(link.name)}">${socialIcon(socialPlatform(link.url))}</a></li>`).join('')}</ul>` : ''}
-    ${owns ? `<a class="profile-edit-button" href="/account/profile"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 5 4 4M4 20l4-1L20 7a2.8 2.8 0 0 0-4-4L4 15Z"/></svg>${profileMessages(lang).title}</a>` : ''}</div>`;
+    ${owns ? `<a class="profile-edit-button" href="/account/profile" aria-label="${profileMessages(lang).title}" title="${profileMessages(lang).title}"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 5 4 4M4 20l4-1L20 7a2.8 2.8 0 0 0-4-4L4 15Z"/></svg></a>` : ''}
+    ${user.socialLinks.length || owns ? '</div>' : ''}</div>`;
 }
 
 export function profileEditPage(user: User, csrf: string, lang: Lang, value: ProfileInput = user, error = '', saved = false): string {

--- a/src/output/youtube.ts
+++ b/src/output/youtube.ts
@@ -840,7 +840,7 @@ export function youtubeDashboardPage(
     <div class="yt-profile-copy"><div class="eyebrow">${t.eyebrowArchive}</div>
     <h1>${html(ownerName)}<em class="h1-scope" data-youtube-sort-scope>${scope}</em></h1>
     ${options.profileHtml ?? ''}
-    <div class="yt-profile-meta"><a href="/">${t.home}</a>${options.blendHref ? ` · <a href="${html(options.blendHref)}">${html(t.memberProfileBlend)}</a>` : ''}</div>${options.friendshipHtml ? `<div class="yt-friendship">${options.friendshipHtml}</div>` : ''}</div></section>`;
+    ${options.blendHref ? `<div class="yt-profile-meta"><a href="${html(options.blendHref)}">${html(t.memberProfileBlend)}</a></div>` : ''}${options.friendshipHtml ? `<div class="yt-friendship">${options.friendshipHtml}</div>` : ''}</div></section>`;
   const showRecent = options.showRecent !== false;
   const overview = page === 'overview' ? hero + (options.setupHtml ?? '') + (options.v3Html ?? '') + stableTopics
     + `<div class="yt-overview-dynamics">${channelChase(data, t)}${topicDynamics(data, t)}</div>`


### PR DESCRIPTION
The profile header stacked a long edit button and a redundant Home button below the social links. Replace the edit control with a 44×44 pencil icon aligned with the social icons, preserving its localized tooltip and accessible name. Remove the profile-area Home link while retaining the header logo's home navigation, Blend and friendship actions.

Validation: TypeScript and full test suite; local browser confirms the edit and social controls align and the profile-area Home link is absent.
