### PR TITLE
Verify deployed app source before recording CD success

### DIFF
--- a/scripts/cd/README.md
+++ b/scripts/cd/README.md
@@ -51,8 +51,11 @@ running source revision and health, then replace state with that verified
 notification is configured. Pause with `systemctl --user stop urtube-cd.timer`.
 Stopping the timer does not interrupt an already running deployment.
 
-Public health confirms availability, not source identity. Deployment source
-identity must be guaranteed by the reviewed host script and its evidence.
+Public health confirms availability, not source identity. After deployment, the
+agent also compares the running app source and build inputs with the GitHub
+archive for the exact commit. A concurrent deployment or source mismatch blocks
+success recording and cache cleanup. This detects competing deployments; the
+local lock only serializes this agent, so operators must coordinate manual releases.
 Changes to the CD agent itself require explicit installation; a new main commit
 does not silently replace the deployment control program.
 

--- a/scripts/cd/test_cd.py
+++ b/scripts/cd/test_cd.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 with tempfile.TemporaryDirectory() as directory:
     cd.STATE = Path(directory)
     cd.save({"deployed": "b" * 40})
-    with patch("sys.argv", ["urtube-cd.py", "--deploy"]), patch.object(cd, "candidate", return_value=sha), patch.object(cd, "get_json", return_value={"object": {"sha": sha}}), patch.object(cd, "healthy"), patch.object(cd.subprocess, "run", side_effect=RuntimeError("synthetic deployment failure")) as deploy:
+    with patch("sys.argv", ["urtube-cd.py", "--deploy"]), patch.object(cd, "candidate", return_value=sha), patch.object(cd, "get_json", return_value={"object": {"sha": sha}}), patch.object(cd, "healthy"), patch.object(cd, "verify_source"), patch.object(cd.subprocess, "run", side_effect=RuntimeError("synthetic deployment failure")) as deploy:
         for _ in range(2):
             try:
                 cd.main()
@@ -30,7 +30,7 @@ with tempfile.TemporaryDirectory() as directory:
         assert deploy.call_count == 1
         assert cd.json.loads((cd.STATE / "state.json").read_text())["attempted"] == sha
     cd.save({"deployed": "b" * 40})
-    with patch("sys.argv", ["urtube-cd.py", "--deploy"]), patch.object(cd, "candidate", return_value=sha), patch.object(cd, "get_json", return_value={"object": {"sha": sha}}), patch.object(cd, "healthy"), patch.object(cd.subprocess, "run") as deploy:
+    with patch("sys.argv", ["urtube-cd.py", "--deploy"]), patch.object(cd, "candidate", return_value=sha), patch.object(cd, "get_json", return_value={"object": {"sha": sha}}), patch.object(cd, "healthy"), patch.object(cd, "verify_source"), patch.object(cd.subprocess, "run") as deploy:
         cd.main()
         cd.main()
         assert deploy.call_count == 3
@@ -38,3 +38,29 @@ with tempfile.TemporaryDirectory() as directory:
         assert deploy.call_args_list[2].args[0][1:] == ["builder", "prune", "--force", "--filter", "until=168h", "--reserved-space", "2GB"]
         assert cd.json.loads((cd.STATE / "state.json").read_text()) == {"deployed": sha}
 print("CD success and failure-state checks passed")
+
+# Archive comparison detects changed or additional application code.
+def archive_bytes(files):
+    stream = cd.io.BytesIO()
+    with cd.tarfile.open(fileobj=stream, mode="w") as archive:
+        for name, content in files.items():
+            member = cd.tarfile.TarInfo(name)
+            member.size = len(content)
+            archive.addfile(member, cd.io.BytesIO(content))
+    return stream.getvalue()
+expected = cd.source_hashes(archive_bytes({"repo-sha/src/index.ts": b"safe"}), strip_root=True)
+assert expected == cd.source_hashes(archive_bytes({"src/index.ts": b"safe"}))
+assert expected != cd.source_hashes(archive_bytes({"src/index.ts": b"changed"}))
+assert expected != cd.source_hashes(archive_bytes({"src/index.ts": b"safe", "src/extra.ts": b"extra"}))
+with tempfile.TemporaryDirectory() as directory:
+    cd.STATE = Path(directory)
+    cd.save({"deployed": "b" * 40})
+    with patch("sys.argv", ["urtube-cd.py", "--deploy"]), patch.object(cd, "candidate", return_value=sha), patch.object(cd, "get_json", return_value={"object": {"sha": sha}}), patch.object(cd, "healthy"), patch.object(cd, "verify_source", side_effect=RuntimeError("concurrent deployment")), patch.object(cd.subprocess, "run") as deploy:
+        try:
+            cd.main()
+            raise AssertionError("source mismatch must block success and pruning")
+        except RuntimeError:
+            pass
+        assert deploy.call_count == 1
+        assert cd.json.loads((cd.STATE / "state.json").read_text())["attempted"] == sha
+print("Source mismatch blocks deployment success and cache pruning")

--- a/scripts/cd/urtube-cd.py
+++ b/scripts/cd/urtube-cd.py
@@ -2,12 +2,15 @@
 """Poll the public repository and deploy only a successful main push commit."""
 import argparse
 import fcntl
+import hashlib
+import io
 import json
 import os
 from pathlib import Path
 import re
 import subprocess
 import time
+import tarfile
 from urllib.request import Request, urlopen
 
 API = "https://api.github.com/repos/skyhong2002/urtube.observe.tw"
@@ -57,6 +60,31 @@ def healthy():
             time.sleep(10)
 
 
+SOURCE_PATHS = ("src/", "scripts/", "public/landing/", "chrome-extension/")
+SOURCE_FILES = {"package.json", "package-lock.json", "tsconfig.json", "favicon.svg", "og.png"}
+
+
+def source_hashes(data, strip_root=False):
+    with tarfile.open(fileobj=io.BytesIO(data)) as archive:
+        hashes = {}
+        for member in archive:
+            name = member.name.partition("/")[2] if strip_root else member.name.removeprefix("./")
+            if member.isfile() and (name in SOURCE_FILES or name.startswith(SOURCE_PATHS)):
+                hashes[name] = hashlib.sha256(archive.extractfile(member).read()).hexdigest()
+        if "src/index.ts" not in hashes:
+            raise RuntimeError("Missing app source in archive")
+        return hashes
+
+
+def verify_source(sha):
+    with urlopen("https://codeload.github.com/skyhong2002/urtube.observe.tw/tar.gz/" + sha, timeout=30) as response:
+        expected = source_hashes(response.read(), strip_root=True)
+    paths = [*SOURCE_PATHS, *sorted(SOURCE_FILES)]
+    actual = subprocess.check_output([str(Path.home() / ".local/bin/docker"), "exec", "urtube-app", "tar", "-c", "-C", "/app", *paths], timeout=30)
+    if source_hashes(actual) != expected:
+        raise RuntimeError("Running app source differs from " + sha + "; possible concurrent deployment")
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--deploy", action="store_true", help="invoke the host deployment script; default is read-only")
@@ -90,6 +118,7 @@ def main():
         save(state)
         subprocess.run(["sudo", "-n", "-u", "deck", "/home/deck/urtube-ops/deploy.sh", sha], check=True, timeout=1800)
         healthy()
+        verify_source(sha)
         save({"deployed": sha})
         print("Deployment command and public health checks succeeded:", sha, flush=True)
         docker = str(Path.home() / ".local/bin/docker")


### PR DESCRIPTION
A concurrent manual deployment can replace the app after the deploy helper reports success. Compare the running app source and build inputs against the exact GitHub commit archive before recording deployment success or pruning caches. A mismatch retains the failed-attempt marker for operator inspection.

Validation: synthetic source changes and extra files are detected; a source mismatch blocks success and cache cleanup. Existing CI and deployment-state checks pass. Live investigation confirmed the app matched another branch while health endpoints returned 200.
