### PR TITLE
Publish immutable production images for Komodo

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,7 @@ name: Check
 
 on:
   push:
+    branches-ignore: [codex/production-images]
   pull_request:
 
 permissions:
@@ -15,6 +16,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Test release manifest
+        run: PYTHONDONTWRITEBYTECODE=1 python3 deploy/komodo/test_release.py
 
       - name: Test deployment gate
         run: python3 scripts/cd/test_cd.py
@@ -33,3 +37,67 @@ jobs:
 
       - name: Build production image
         run: docker build -t urtube:${{ github.sha }} .
+
+  publish:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: urtube-image-publication
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish application image
+        id: app
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/skyhong2002/urtube.observe.tw:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/skyhong2002/urtube.observe.tw
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha,scope=urtube-app
+          cache-to: type=gha,mode=max,scope=urtube-app
+      - name: Publish matching compute image
+        id: compute
+        uses: docker/build-push-action@v7
+        with:
+          context: services/matching-compute
+          push: true
+          tags: ghcr.io/skyhong2002/urtube-matching-compute:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/skyhong2002/urtube.observe.tw
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha,scope=urtube-compute
+          cache-to: type=gha,mode=max,scope=urtube-compute
+      - name: Publish deployment manifest
+        env:
+          APP_DIGEST: ${{ steps.app.outputs.digest }}
+          COMPUTE_DIGEST: ${{ steps.compute.outputs.digest }}
+        run: |
+          set -euo pipefail
+          current=$(git ls-remote origin refs/heads/main | cut -f1)
+          if [ "$current" != "$GITHUB_SHA" ]; then
+            echo "Main advanced; the newer workflow will publish the deployment manifest."
+            exit 0
+          fi
+          branch=codex/production-images
+          previous=$(git ls-remote origin "refs/heads/$branch" | cut -f1)
+          python3 deploy/komodo/release.py
+          git switch -C "$branch"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add deploy/komodo/images.json
+          git commit -m "Deploy images for $GITHUB_SHA"
+          git push "--force-with-lease=refs/heads/$branch:$previous" origin "HEAD:refs/heads/$branch"

--- a/deploy/komodo/compose.yaml
+++ b/deploy/komodo/compose.yaml
@@ -1,0 +1,41 @@
+name: komodo
+services:
+  mongo:
+    image: mongo:8.0
+    restart: unless-stopped
+    command: ["--quiet", "--wiredTigerCacheSizeGB", "0.25"]
+    labels:
+      komodo.skip: ""
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: admin
+      MONGO_INITDB_ROOT_PASSWORD: ${KOMODO_DATABASE_PASSWORD:?required}
+    volumes:
+      - mongo-data:/data/db
+      - mongo-config:/data/configdb
+  core:
+    image: ghcr.io/moghtech/komodo-core:2.3.3
+    init: true
+    restart: unless-stopped
+    depends_on:
+      - mongo
+    ports:
+      - "127.0.0.1:9120:9120"
+    env_file: .env
+    environment:
+      KOMODO_DATABASE_ADDRESS: mongo:27017
+      KOMODO_DATABASE_USERNAME: admin
+      KOMODO_HOST: http://localhost:19120
+      KOMODO_TITLE: urtube Deployments
+      KOMODO_LOCAL_AUTH: "true"
+      KOMODO_DISABLE_USER_REGISTRATION: "true"
+      KOMODO_DISABLE_INIT_RESOURCES: "true"
+      KOMODO_RESOURCE_POLL_INTERVAL: 5-min
+      TZ: Asia/Taipei
+    volumes:
+      - keys:/config/keys
+      - backups:/backups
+volumes:
+  mongo-data:
+  mongo-config:
+  keys:
+  backups:

--- a/deploy/komodo/release.py
+++ b/deploy/komodo/release.py
@@ -1,0 +1,18 @@
+"""Generate the atomic, immutable Compose image override published by CI."""
+import json
+import os
+from pathlib import Path
+import re
+
+
+def manifest(app, compute):
+    if not all(re.fullmatch(r"sha256:[0-9a-f]{64}", digest) for digest in (app, compute)):
+        raise ValueError("Both images must have immutable SHA-256 digests")
+    return {"services": {
+        **{name: {"image": "ghcr.io/skyhong2002/urtube.observe.tw@" + app} for name in ("app", "ingest", "worker", "backup", "matching-worker")},
+        **{name: {"image": "ghcr.io/skyhong2002/urtube-matching-compute@" + compute} for name in ("matching-compute", "matching-compare")},
+    }}
+
+
+if __name__ == "__main__":
+    Path(__file__).with_name("images.json").write_text(json.dumps(manifest(os.environ["APP_DIGEST"], os.environ["COMPUTE_DIGEST"]), indent=2) + "\n")

--- a/deploy/komodo/test_release.py
+++ b/deploy/komodo/test_release.py
@@ -1,0 +1,14 @@
+from release import manifest
+
+app, compute = "sha256:" + "a" * 64, "sha256:" + "b" * 64
+services = manifest(app, compute)["services"]
+assert len(services) == 7
+assert all(services[name]["image"].endswith(app) for name in ("app", "ingest", "worker", "backup", "matching-worker"))
+assert all(services[name]["image"].endswith(compute) for name in ("matching-compute", "matching-compare"))
+for bad in ("latest", "sha256:", "sha256:" + "x" * 64):
+    try:
+        manifest(app, bad)
+        raise AssertionError("mutable or invalid image must fail")
+    except ValueError:
+        pass
+print("Release manifest checks passed")

--- a/docs/plans/2026-09-06-komodo.md
+++ b/docs/plans/2026-09-06-komodo.md
@@ -1,0 +1,7 @@
+# Komodo deployment plan
+
+Use GitHub Actions to build both production images after tests, publish immutable GHCR digests, and write a release Compose override to `codex/production-images`. Komodo's scheduled DeployStackIfChanged consumes that branch with the preserved host Compose settings. Native pre/post deployment hooks perform the existing snapshot and health checks, then Docker's supported cache cleanup. Komodo Core runs with MongoDB; Periphery runs as the existing urtube user. Keep credentials off Git and the UI on loopback, accessible through SSH.
+
+1. Install pinned Komodo and register the existing host without touching app containers.
+2. Build and validate GHCR release publishing and deploy the Compose project with matching project/volume names and no host build.
+3. Verify backup, image digests, service health, native scheduled no-op behavior and cleanup; disable and remove the custom Python timer only when the native pipeline is ready.


### PR DESCRIPTION
Replace host-side builds with CI-published application and matching-compute images. After main tests pass and both images publish, write their immutable digests together to the codex/production-images deployment branch. Komodo will consume this branch through its native scheduled Compose deployment.

Includes the pinned Komodo Core/MongoDB Compose setup and synthetic release-manifest validation. The current deployment timer remains active until Komodo has completed a verified cutover; credentials and existing production settings remain host-local.

Validation: release-manifest checks and git diff --check pass; Komodo Core 2.3.3 is running on the host with loopback-only UI access. End-to-end registry publication and Komodo deployment will be validated after merge.
